### PR TITLE
Enhance future trip visibility in public map

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Aplicación web completa para crear y visualizar mapas interactivos de viajes co
     - Meta descripción para optimización en buscadores
     - Favicon personalizable
     - Integración de Google Analytics u otros scripts de análisis
--- **Importador Flight Radar**: FlightRadar CSV import por Xyborg
+- **Importador Flight Radar**: FlightRadar CSV import por [@Xyborg](https://github.com/Xyborg)
 
 ### Visualizador Público
 - **Mapa a Pantalla Completa**: Interfaz responsive con todos los viajes y puntos publicados

--- a/assets/css/public_map.css
+++ b/assets/css/public_map.css
@@ -124,6 +124,16 @@ body {
     margin-right: 12px;
 }
 
+/* Future trips styling */
+.trip-filter-item.trip-future {
+    background: linear-gradient(135deg, #f8f9fa 0%, #f0f0f0 100%);
+    border-left: 3px dotted #6B6B6B;
+}
+
+.trip-filter-item.trip-future:hover {
+    background: linear-gradient(135deg, #f0f0f0 0%, #e8e8e8 100%);
+}
+
 /* ========== Leyenda flotante ========== */
 .legend-card {
     position: fixed;
@@ -164,6 +174,17 @@ body {
 
 .legend-item svg {
     flex-shrink: 0;
+}
+
+.legend-future-separator {
+    margin-top: 8px;
+    padding-top: 8px;
+    border-top: 1px dashed #ddd;
+}
+
+.legend-future {
+    height: 3px !important;
+    opacity: 0.6;
 }
 
 /* ========== Clusters personalizados ========== */


### PR DESCRIPTION
- Added styling for future trips in the CSS, including a distinct background and hover effects.
- Updated JavaScript to include future trip indicators in the legend and trip listings.
- Implemented logic to determine if a trip is future based on its start date, with corresponding visual cues in the map and popups.

<img width="3024" height="1626" alt="image" src="https://github.com/user-attachments/assets/2cca7587-6fef-40b5-99a1-b4fe85b83173" />
