### PR TITLE
Enhancement: Add Bike to transport types.

### DIFF
--- a/admin/settings.php
+++ b/admin/settings.php
@@ -670,7 +670,7 @@ require_once __DIR__ . '/../includes/header.php';
                         'plane' => '#FF4444',
                         'ship' => '#00AAAA',
                         'car' => '#4444FF',
-                        'bike' => '#b88907ac',
+                        'bike' => '#b88907',
                         'train' => '#FF8800',
                         'walk' => '#44FF44',
                         'bus' => '#9C27B0',

--- a/assets/js/public_map.js
+++ b/assets/js/public_map.js
@@ -118,7 +118,7 @@
         'plane': { color: '#FF4444', icon: transportIcons.plane, dashArray: [10, 5] },
         'ship': { color: '#00AAAA', icon: transportIcons.ship, dashArray: [10, 5] },
         'car': { color: '#4444FF', icon: transportIcons.car, dashArray: null },
-        'bike': { color: '#b88907ac', icon: transportIcons.bike, dashArray: null },
+        'bike': { color: '#b88907', icon: transportIcons.bike, dashArray: null },
         'train': { color: '#FF8800', icon: transportIcons.train, dashArray: null },
         'walk': { color: '#44FF44', icon: transportIcons.walk, dashArray: null },
         'bus': { color: '#9C27B0', icon: transportIcons.bus, dashArray: null },

--- a/assets/js/public_map_leaflet.js
+++ b/assets/js/public_map_leaflet.js
@@ -280,7 +280,7 @@
         'plane': { color: '#FF4444', icon: transportIcons.plane, dashArray: '10, 5' },
         'ship': { color: '#00AAAA', icon: transportIcons.ship, dashArray: '10, 5' },
         'car': { color: '#4444FF', icon: transportIcons.car, dashArray: null },
-        'bike': { color: '#b88907ac', icon: transportIcons.bike, dashArray: null },
+        'bike': { color: '#b88907', icon: transportIcons.bike, dashArray: null },
         'train': { color: '#FF8800', icon: transportIcons.train, dashArray: null },
         'walk': { color: '#44FF44', icon: transportIcons.walk, dashArray: null },
         'bus': { color: '#9C27B0', icon: transportIcons.bus, dashArray: null },

--- a/assets/js/trip_map.js
+++ b/assets/js/trip_map.js
@@ -31,7 +31,7 @@
     let transportColors = {
         'plane': '#FF4444',
         'car': '#4444FF',
-        'bike': '#b88907ac',
+        'bike': '#b88907',
         'train': '#FF8800',
         'ship': '#00AAAA',
         'walk': '#44FF44',

--- a/database.sql
+++ b/database.sql
@@ -108,7 +108,7 @@ INSERT INTO settings (setting_key, setting_value, setting_type, description) VAL
 ('transport_color_plane', '#FF4444', 'string', 'Color para rutas en avión'),
 ('transport_color_ship', '#00AAAA', 'string', 'Color para rutas en barco'),
 ('transport_color_car', '#4444FF', 'string', 'Color para rutas en auto'),
-('transport_color_bike', '#b88907ac', 'string', 'Color para rutas en motocicleta'),
+('transport_color_bike', '#b88907', 'string', 'Color para rutas en motocicleta'),
 ('transport_color_train', '#FF8800', 'string', 'Color para rutas en tren'),
 ('transport_color_walk', '#44FF44', 'string', 'Color para rutas caminando'),
 ('transport_color_bus', '#9C27B0', 'string', 'Color para rutas en bus'),

--- a/install/migrate_add_bike_transport_type.php
+++ b/install/migrate_add_bike_transport_type.php
@@ -34,7 +34,7 @@ try {
     echo "\n2. Adding default color settings...\n";
     
     $newSettings = [
-        ['transport_color_bike', '#b88907ac', 'string', 'Color para rutas en motocicleta (bicicleta, motocicleta, cuatriciclos, etc.)']
+        ['transport_color_bike', '#b88907', 'string', 'Color para rutas en motocicleta (bicicleta, motocicleta, cuatriciclos, etc.)']
     ];
     
     $insertStmt = $db->prepare("

--- a/install/migration_add_bike_transport_type.sql
+++ b/install/migration_add_bike_transport_type.sql
@@ -10,5 +10,5 @@ MODIFY COLUMN transport_type ENUM('plane', 'car', 'walk', 'ship', 'train', 'bike
 
 -- Insert default color settings for new transport types
 INSERT INTO settings (setting_key, setting_value, setting_type, description) VALUES
-('transport_color_bike', '#b88907ac', 'string', 'Color para rutas en motocicleta (bicicleta, motocicleta, cuatriciclos, etc.)')
+('transport_color_bike', '#b88907', 'string', 'Color para rutas en motocicleta (bicicleta, motocicleta, cuatriciclos, etc.)')
 ON DUPLICATE KEY UPDATE setting_key = setting_key;

--- a/lang/en.json
+++ b/lang/en.json
@@ -365,6 +365,7 @@
     "transport_plane": "Plane",
     "transport_ship": "Ship",
     "transport_car": "Car",
+    "transport_bike": "Bike",
     "transport_train": "Train",
     "transport_walk": "Walking",
     "transport_bus": "Bus",

--- a/lang/es.json
+++ b/lang/es.json
@@ -367,6 +367,7 @@
     "transport_plane": "Avión",
     "transport_ship": "Barco",
     "transport_car": "Auto",
+    "transport_bike": "Motocicleta",
     "transport_train": "Tren",
     "transport_walk": "Caminata",
     "transport_bus": "Autobús",

--- a/src/models/Route.php
+++ b/src/models/Route.php
@@ -175,7 +175,7 @@ class Route {
         $colors = [
             'plane' => '#FF4444',    // Rojo
             'car' => '#4444FF',      // Azul
-            'bike' => '#b88907ac',   // Marrón
+            'bike' => '#b88907',     // Marrón
             'walk' => '#44FF44',     // Verde
             'ship' => '#00AAAA',     // Cyan
             'train' => '#FF8800',    // Naranja


### PR DESCRIPTION
- Synchronized all 8 transport types (plane, ship, car, bike, train, walk, bus, and aerial) across all map views:
    - assets/js/public_map.js: Added 'bus' and 'aerial' (icons, configuration, and legend).
    - assets/js/public_map_leaflet.js: Added 'bike' and updated legend consistency.
- Updated translation files (lang/en.json and lang/es.json) to include 'bike' transport type.
- Refined migration scripts (PHP and SQL) for the 'bike' transport type with more comprehensive descriptions.

Admin
<img width="1391" height="781" alt="Captura de pantalla 2026-01-08 a la(s) 19 59 56" src="https://github.com/user-attachments/assets/77cf87ec-7cd1-42b6-ac6a-67c286c31dc4" />

Public
<img width="624" height="520" alt="Captura de pantalla 2026-01-08 a la(s) 20 00 22" src="https://github.com/user-attachments/assets/4eed21f4-e2e0-484a-a86f-0581dc9ded4f" />
