### PR TITLE
chore: exclude config files from repo, add example templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,18 +1,32 @@
+# ── Configuración local — NUNCA subir al repo ─────────────────────────────────
+config/config.php
+config/db.php
+
+# ── Uploads de usuarios ───────────────────────────────────────────────────────
 uploads/
-up/flightdiary_*.csv
 up/
-.DS_Store
-assets/css/public_map_leaflet_backup.css
-assets/js/point_map_leaflet_backup.js
-assets/js/trip_map_leaflet_backup.js
-assets/js/public_map_leaflet_backup.js
-flightdiary_2025_12_29_23_58.csv
+flightdiary_*.csv
+
+# ── Backups ───────────────────────────────────────────────────────────────────
 backups/*.json
+
+# ── Archivos de sistema ───────────────────────────────────────────────────────
+.DS_Store
 *.db
+
+# ── Archivos de desarrollo / debug ───────────────────────────────────────────
+info.php
 admin/phpminiadmin.php
+
+# ── Docker ────────────────────────────────────────────────────────────────────
 docker-compose.yml
 docker-entrypoint.sh
 README_DOCKER.md
 Dockerfile
-info.php
+
+# ── Otros ─────────────────────────────────────────────────────────────────────
 CLAUDE.md
+assets/css/public_map_leaflet_backup.css
+assets/js/point_map_leaflet_backup.js
+assets/js/trip_map_leaflet_backup.js
+assets/js/public_map_leaflet_backup.js

--- a/README.md
+++ b/README.md
@@ -179,21 +179,28 @@ c:\xampp\htdocs\TravelMap
 - Importa el archivo [database.sql](database.sql)
 - Esto creará la base de datos `travelmap` con todas las tablas necesarias
 
-### 3. Configurar la Conexión a la Base de Datos
-Edita [config/db.php](config/db.php) si tus credenciales son diferentes:
+### 3. Configurar los archivos de conexión
+
+En la carpeta `config/` encontrarás dos archivos de ejemplo:
+
+- `config.example.php` → copiarlo y renombrarlo como `config.php`
+- `db.example.php` → copiarlo y renombrarlo como `db.php`
+
+**Editar `config/db.php`** con las credenciales de tu base de datos:
 ```php
-// Valores por defecto
-'user' => 'root',
-'password' => ''  // vacía
+private const DB_HOST = '127.0.0.1';
+private const DB_NAME = 'travelmap';
+private const DB_USER = 'root';
+private const DB_PASS = '';          // tu contraseña
 ```
 
-### 4. Ajustar la URL Base
-Edita [config/config.php](config/config.php):
+**Editar `config/config.php`** con la carpeta de instalación:
 ```php
-$folder = 'TravelMap';  // Cambia si tu carpeta tiene otro nombre
+$folder = '/TravelMap';  // Cambia si tu carpeta tiene otro nombre
+                         // Usa '' si está en la raíz del dominio
 ```
 
-### 5. Crear Usuario Administrador
+### 4. Crear Usuario Administrador
 Accede a la URL de instalación (solo una vez):
 ```
 http://localhost/TravelMap/install/seed_admin.php
@@ -205,10 +212,18 @@ Esto creará el usuario administrador:
 
 **⚠️ IMPORTANTE**: Elimina o protege la carpeta `install/` después de ejecutar este paso.
 
-### 6. Acceder a la Aplicación
+### 5. Acceder a la Aplicación
 
 - **Panel Administrativo**: [http://localhost/TravelMap/admin/](http://localhost/TravelMap/admin/)
 - **Vista Pública**: [http://localhost/TravelMap/](http://localhost/TravelMap/)
+
+### Actualizar a una nueva versión
+
+Si ya tenés el proyecto instalado y querés actualizar:
+
+1. Descargá el ZIP de la nueva versión desde GitHub
+2. Descomprimilo y subí todos los archivos por FTP — `config.php` y `db.php` no están en el ZIP, así que tu configuración nunca será sobreescrita
+3. Si la nueva versión incluye migraciones de base de datos, ejecutá los scripts en `install/`
 
 ## 📖 Guía de Uso
 
@@ -304,6 +319,7 @@ El sistema i18n requiere una migración de base de datos. Ver instrucciones comp
 - Protección de rutas administrativas mediante autenticación
 - Foreign Keys con restricciones CASCADE para integridad referencial
 - Preparación de consultas SQL con PDO (prevención de SQL injection)
+- **Archivos de configuración excluidos del ZIP de distribución** — `config.php` y `db.php` nunca se distribuyen con el proyecto
 
 ## 📁 Estructura del Proyecto
 

--- a/config/config.example.php
+++ b/config/config.example.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Configuración Global del Proyecto
+ *
+ * INSTRUCCIONES:
+ *   1. Copiá este archivo como config.php
+ *   2. Editá los valores según tu entorno
+ *   3. Nunca subas config.php a Git — ya está en .gitignore
+ */
+
+// Configuración de errores
+// En producción usar: error_reporting(0); ini_set('display_errors', 0);
+error_reporting(E_ALL);
+ini_set('display_errors', 1);
+
+// Ruta raíz del proyecto
+define('ROOT_PATH', dirname(__DIR__));
+
+// Carpeta del proyecto en el servidor (cambiar según tu instalación)
+// Ejemplos:
+//   Local XAMPP:   '/TravelMap'
+//   Producción:    ''   (si está en la raíz del dominio)
+$protocol = isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? 'https' : 'http';
+$host     = $_SERVER['HTTP_HOST'] ?? 'localhost';
+$folder   = '/TravelMap'; // <-- CAMBIAR AQUÍ
+
+define('BASE_URL', $protocol . '://' . $host . $folder);
+
+// Rutas de directorios importantes
+define('CONFIG_PATH', ROOT_PATH . '/config');
+define('UPLOADS_PATH', ROOT_PATH . '/uploads');
+define('ASSETS_PATH',  ROOT_PATH . '/assets');
+define('SRC_PATH',     ROOT_PATH . '/src');
+
+// URLs de recursos
+define('ASSETS_URL',  BASE_URL . '/assets');
+define('UPLOADS_URL', BASE_URL . '/uploads');
+
+// Valores por defecto (se sobreescriben desde la BD si está disponible)
+$defaultTimezone          = 'America/Argentina/Buenos_Aires';
+$defaultMaxUploadSize     = 8 * 1024 * 1024; // 8MB
+$defaultSessionLifetime   = 3600 * 24;        // 24 horas
+$defaultImageMaxWidth     = 1920;
+$defaultImageMaxHeight    = 1080;
+$defaultImageQuality      = 85;
+$defaultSiteTitle         = 'Travel Map - Mis Viajes por el Mundo';
+$defaultSiteDescription   = 'Explora mis viajes por el mundo con mapas interactivos, rutas y fotografías';
+$defaultSiteFavicon       = '';
+$defaultSiteAnalyticsCode = '';
+
+// Intentar cargar configuraciones dinámicas desde la base de datos
+try {
+    require_once CONFIG_PATH . '/db.php';
+    require_once SRC_PATH . '/models/Settings.php';
+
+    $conn          = getDB();
+    $settingsModel = new Settings($conn);
+
+    $timezone          = $settingsModel->get('timezone',          $defaultTimezone);
+    $maxUploadSize     = $settingsModel->get('max_upload_size',   $defaultMaxUploadSize);
+    $sessionLifetime   = $settingsModel->get('session_lifetime',  $defaultSessionLifetime);
+    $imageMaxWidth     = $settingsModel->get('image_max_width',   $defaultImageMaxWidth);
+    $imageMaxHeight    = $settingsModel->get('image_max_height',  $defaultImageMaxHeight);
+    $imageQuality      = $settingsModel->get('image_quality',     $defaultImageQuality);
+    $siteTitle         = $settingsModel->get('site_title',        $defaultSiteTitle);
+    $siteDescription   = $settingsModel->get('site_description',  $defaultSiteDescription);
+    $siteFavicon       = $settingsModel->get('site_favicon',      $defaultSiteFavicon);
+    $siteAnalyticsCode = $settingsModel->get('site_analytics_code', $defaultSiteAnalyticsCode);
+} catch (Exception $e) {
+    error_log('Error al cargar configuraciones: ' . $e->getMessage());
+    $timezone          = $defaultTimezone;
+    $maxUploadSize     = $defaultMaxUploadSize;
+    $sessionLifetime   = $defaultSessionLifetime;
+    $imageMaxWidth     = $defaultImageMaxWidth;
+    $imageMaxHeight    = $defaultImageMaxHeight;
+    $imageQuality      = $defaultImageQuality;
+    $siteTitle         = $defaultSiteTitle;
+    $siteDescription   = $defaultSiteDescription;
+    $siteFavicon       = $defaultSiteFavicon;
+    $siteAnalyticsCode = $defaultSiteAnalyticsCode;
+}
+
+// Aplicar configuraciones
+date_default_timezone_set($timezone);
+
+define('MAX_UPLOAD_SIZE',          $maxUploadSize);
+define('ALLOWED_IMAGE_TYPES',      ['image/jpeg', 'image/png', 'image/jpg']);
+define('ALLOWED_IMAGE_EXTENSIONS', ['jpg', 'jpeg', 'png']);
+define('IMAGE_MAX_WIDTH',          $imageMaxWidth);
+define('IMAGE_MAX_HEIGHT',         $imageMaxHeight);
+define('IMAGE_QUALITY',            $imageQuality);
+define('SITE_TITLE',               $siteTitle);
+define('SITE_DESCRIPTION',         $siteDescription);
+define('SITE_FAVICON',             $siteFavicon);
+define('SITE_ANALYTICS_CODE',      $siteAnalyticsCode);
+define('SESSION_LIFETIME',         $sessionLifetime);
+
+// Cargar sistema de internacionalización (i18n)
+require_once SRC_PATH . '/helpers/Language.php';
+$lang = Language::getInstance();

--- a/config/db.example.php
+++ b/config/db.example.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Conexión a Base de Datos
+ *
+ * INSTRUCCIONES:
+ *   1. Copiá este archivo como db.php
+ *   2. Editá las credenciales según tu entorno
+ *   3. Nunca subas db.php a Git — ya está en .gitignore
+ */
+
+class Database {
+    private static $instance = null;
+    private $connection;
+
+    // ── Credenciales — CAMBIAR SEGÚN TU ENTORNO ──────────────────────────────
+    private const DB_HOST    = '127.0.0.1'; // 'localhost' también válido
+    private const DB_NAME    = 'travelmap';
+    private const DB_USER    = 'root';
+    private const DB_PASS    = '';          // contraseña de tu BD
+    private const DB_CHARSET = 'utf8mb4';
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private function __construct() {
+        try {
+            $dsn = sprintf(
+                'mysql:host=%s;dbname=%s;charset=%s',
+                self::DB_HOST,
+                self::DB_NAME,
+                self::DB_CHARSET
+            );
+
+            $options = [
+                PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+                PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+                PDO::ATTR_EMULATE_PREPARES   => false,
+            ];
+
+            $this->connection = new PDO($dsn, self::DB_USER, self::DB_PASS, $options);
+        } catch (PDOException $e) {
+            die('Error de conexión a la base de datos: ' . $e->getMessage());
+        }
+    }
+
+    public static function getInstance() {
+        if (self::$instance === null) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    public function getConnection() {
+        return $this->connection;
+    }
+
+    private function __clone() {}
+
+    public function __wakeup() {
+        throw new Exception("No se puede deserializar un singleton.");
+    }
+}
+
+function getDB() {
+    return Database::getInstance()->getConnection();
+}


### PR DESCRIPTION
- config/config.example.php: template for config.php with setup instructions
- config/db.example.php: template for db.php with credential placeholders
- .gitignore: add config/config.php and config/db.php to ignored files
- README.md: update installation steps to reflect the new config workflow, add section explaining how to update without overwriting local config