### PR TITLE
feat(poi): add typed external links to points of interest

### DIFF
--- a/admin/point_form.php
+++ b/admin/point_form.php
@@ -14,10 +14,12 @@ require_auth();
 require_once __DIR__ . '/../config/db.php';
 require_once __DIR__ . '/../src/models/Point.php';
 require_once __DIR__ . '/../src/models/Trip.php';
+require_once __DIR__ . '/../src/models/PoiLink.php';
 require_once __DIR__ . '/../src/helpers/FileHelper.php';
 
 $pointModel = new Point();
-$tripModel = new Trip();
+$tripModel  = new Trip();
+$poiLinkModel = new PoiLink();
 $errors = [];
 $success = false;
 $point = null;
@@ -71,9 +73,27 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
 
     if (empty($errors)) {
+        // Preparar links enviados en el formulario
+        $submitted_links = [];
+        $link_types  = $_POST['link_type']  ?? [];
+        $link_urls   = $_POST['link_url']   ?? [];
+        $link_labels = $_POST['link_label'] ?? [];
+        foreach ($link_types as $i => $ltype) {
+            $lurl = trim($link_urls[$i] ?? '');
+            if ($lurl !== '') {
+                $submitted_links[] = [
+                    'link_type'  => $ltype,
+                    'url'        => $lurl,
+                    'label'      => trim($link_labels[$i] ?? ''),
+                    'sort_order' => $i,
+                ];
+            }
+        }
+
         if ($is_edit) {
             // Actualizar
             if ($pointModel->update($point_id, $data)) {
+                $poiLinkModel->replaceForPoi($point_id, $submitted_links);
                 $success = true;
                 $point = $pointModel->getById($point_id); // Recargar datos
                 $message = __('points.updated_success');
@@ -84,6 +104,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             // Crear
             $new_id = $pointModel->create($data);
             if ($new_id) {
+                $poiLinkModel->replaceForPoi((int) $new_id, $submitted_links);
                 $success = true;
                 $message = __('points.saved_success');
                 // Redirigir a edición del nuevo punto
@@ -112,7 +133,9 @@ $form_data = $point ?? [
     'image_path' => null
 ];
 
-$point_types = Point::getTypes();
+$point_types  = Point::getTypes();
+$link_types   = PoiLink::getTypes();
+$existing_links = ($is_edit && $point) ? $poiLinkModel->getByPoiId($point['id']) : [];
 ?>
 
 <div class="row mb-4">
@@ -389,6 +412,71 @@ $point_types = Point::getTypes();
                         <?php endif; ?>
                     </div>
 
+                    <!-- Links externos -->
+                    <div class="mb-3">
+                        <label class="form-label">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-link-45deg me-1" viewBox="0 0 16 16">
+                                <path d="M4.715 6.542 3.343 7.914a3 3 0 1 0 4.243 4.243l1.828-1.829A3 3 0 0 0 8.586 5.5L8 6.086a1 1 0 0 0-.154.199 2 2 0 0 1 .861 3.337L6.88 11.45a2 2 0 1 1-2.83-2.83l.793-.792a4 4 0 0 1-.128-1.287z"/>
+                                <path d="M6.586 4.672A3 3 0 0 0 7.414 9.5l.775-.776a2 2 0 0 1-.896-3.346L9.12 3.55a2 2 0 1 1 2.83 2.83l-.793.792c.112.42.155.855.128 1.287l1.372-1.372a3 3 0 1 0-4.243-4.243z"/>
+                            </svg>
+                            <?= __('points.external_links') ?>
+                        </label>
+
+                        <div id="poi-links-container">
+                            <?php foreach ($existing_links as $i => $lnk): ?>
+                            <div class="poi-link-row input-group mb-2">
+                                <select name="link_type[]" class="form-select" style="max-width: 180px;">
+                                    <?php foreach ($link_types as $lkey => $lmeta): ?>
+                                        <option value="<?= $lkey ?>" <?= $lnk['link_type'] === $lkey ? 'selected' : '' ?>>
+                                            <?= htmlspecialchars($lmeta['label']) ?>
+                                        </option>
+                                    <?php endforeach; ?>
+                                </select>
+                                <input type="url" name="link_url[]" class="form-control"
+                                       placeholder="https://" value="<?= htmlspecialchars($lnk['url']) ?>" required>
+                                <input type="text" name="link_label[]" class="form-control"
+                                       placeholder="<?= __('points.link_label_optional') ?>"
+                                       style="max-width: 160px;"
+                                       value="<?= htmlspecialchars($lnk['label'] ?? '') ?>">
+                                <button type="button" class="btn btn-outline-danger remove-link-btn" title="<?= __('common.remove') ?>">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-trash" viewBox="0 0 16 16">
+                                        <path d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0z"/>
+                                        <path fill-rule="evenodd" d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1zM4.118 4 4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4zM2.5 3h11V2h-11z"/>
+                                    </svg>
+                                </button>
+                            </div>
+                            <?php endforeach; ?>
+                        </div>
+
+                        <button type="button" id="add-link-btn" class="btn btn-outline-secondary btn-sm mt-1">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-plus-lg me-1" viewBox="0 0 16 16">
+                                <path fill-rule="evenodd" d="M8 2a.5.5 0 0 1 .5.5v5h5a.5.5 0 0 1 0 1h-5v5a.5.5 0 0 1-1 0v-5h-5a.5.5 0 0 1 0-1h5v-5A.5.5 0 0 1 8 2"/>
+                            </svg>
+                            <?= __('points.add_link') ?>
+                        </button>
+
+                        <!-- Template row (hidden) -->
+                        <template id="link-row-template">
+                            <div class="poi-link-row input-group mb-2">
+                                <select name="link_type[]" class="form-select" style="max-width: 180px;">
+                                    <?php foreach ($link_types as $lkey => $lmeta): ?>
+                                        <option value="<?= $lkey ?>"><?= htmlspecialchars($lmeta['label']) ?></option>
+                                    <?php endforeach; ?>
+                                </select>
+                                <input type="url" name="link_url[]" class="form-control" placeholder="https://" required>
+                                <input type="text" name="link_label[]" class="form-control"
+                                       placeholder="<?= __('points.link_label_optional') ?>"
+                                       style="max-width: 160px;">
+                                <button type="button" class="btn btn-outline-danger remove-link-btn" title="<?= __('common.remove') ?>">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-trash" viewBox="0 0 16 16">
+                                        <path d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0z"/>
+                                        <path fill-rule="evenodd" d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1zM4.118 4 4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4zM2.5 3h11V2h-11z"/>
+                                    </svg>
+                                </button>
+                            </div>
+                        </template>
+                    </div>
+
                     <div class="d-grid gap-2 d-md-flex justify-content-md-end mt-4">
                         <a href="points.php<?= isset($_GET['trip_id']) ? '?trip_id=' . $_GET['trip_id'] : '' ?>" class="btn btn-secondary"><?= __('common.cancel') ?></a>
                         <button type="submit" class="btn btn-primary">
@@ -464,6 +552,32 @@ const initialLng = <?= !empty($form_data['longitude']) ? $form_data['longitude']
 
 <!-- Script del mapa de puntos -->
 <script src="<?= ASSETS_URL ?>/js/point_map.js?v=<?php echo $version; ?>"></script>
+
+<script>
+// POI Links — add/remove rows
+(function () {
+    const container = document.getElementById('poi-links-container');
+    const template  = document.getElementById('link-row-template');
+    const addBtn    = document.getElementById('add-link-btn');
+
+    function attachRemove(row) {
+        row.querySelector('.remove-link-btn').addEventListener('click', function () {
+            row.remove();
+        });
+    }
+
+    // Attach to existing rows
+    container.querySelectorAll('.poi-link-row').forEach(attachRemove);
+
+    addBtn.addEventListener('click', function () {
+        const clone = template.content.cloneNode(true);
+        const row   = clone.querySelector('.poi-link-row');
+        attachRemove(row);
+        container.appendChild(row);
+        row.querySelector('input[type="url"]').focus();
+    });
+})();
+</script>
 
 <!-- Script para Drag & Drop de imágenes -->
 <script>

--- a/api/get_all_data.php
+++ b/api/get_all_data.php
@@ -13,13 +13,15 @@ require_once __DIR__ . '/../src/models/Trip.php';
 require_once __DIR__ . '/../src/models/Route.php';
 require_once __DIR__ . '/../src/models/Point.php';
 require_once __DIR__ . '/../src/models/TripTag.php';
+require_once __DIR__ . '/../src/models/PoiLink.php';
 require_once __DIR__ . '/../src/helpers/FileHelper.php';
 
 try {
-    $tripModel = new Trip();
-    $routeModel = new Route();
-    $pointModel = new Point();
+    $tripModel    = new Trip();
+    $routeModel   = new Route();
+    $pointModel   = new Point();
     $tripTagModel = new TripTag();
+    $poiLinkModel = new PoiLink();
     
     // Obtener todos los viajes publicados
     $trips = $tripModel->getAll('start_date DESC', 'published');
@@ -68,6 +70,8 @@ try {
                 $thumbnail_url = $thumb_path ? BASE_URL . '/' . $thumb_path : null;
             }
             
+            $links = PoiLink::toApiArray($poiLinkModel->getByPoiId((int) $point['id']));
+
             $processedPoints[] = [
                 'id' => (int) $point['id'],
                 'title' => $point['title'],
@@ -78,7 +82,8 @@ try {
                 'thumbnail_url' => $thumbnail_url,
                 'latitude' => (float) $point['latitude'],
                 'longitude' => (float) $point['longitude'],
-                'visit_date' => $point['visit_date']
+                'visit_date' => $point['visit_date'],
+                'links' => $links,
             ];
         }
         

--- a/assets/css/public_map.css
+++ b/assets/css/public_map.css
@@ -1455,6 +1455,30 @@ body {
     font-family: 'Courier New', monospace;
 }
 
+.popup-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-bottom: 8px;
+}
+
+.popup-link-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    border-radius: 6px;
+    background: #f1f3f5;
+    transition: background 0.15s, transform 0.1s;
+    text-decoration: none;
+}
+
+.popup-link-btn:hover {
+    background: #e2e6ea;
+    transform: scale(1.1);
+}
+
 .route-popup {
     padding: 8px 12px;
 }

--- a/assets/css/trip.css
+++ b/assets/css/trip.css
@@ -318,10 +318,16 @@ body.trip-page {
 
 .point-content {
     display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    flex: 1;
+}
+
+.point-header {
+    display: flex;
     align-items: baseline;
     justify-content: space-between;
     gap: 0.75rem;
-    flex: 1;
 }
 
 .point-title {
@@ -337,6 +343,30 @@ body.trip-page {
     color: #94a3b8;
     white-space: nowrap;
     flex-shrink: 0;
+}
+
+.point-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+    margin-top: 2px;
+}
+
+.point-link-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    border-radius: 5px;
+    background: #f1f3f5;
+    text-decoration: none;
+    transition: background 0.15s, transform 0.1s;
+}
+
+.point-link-btn:hover {
+    background: #dee2e6;
+    transform: scale(1.12);
 }
 
 /* Winding route SVG path */

--- a/assets/js/public_map.js
+++ b/assets/js/public_map.js
@@ -784,6 +784,16 @@
             html += `<p class="popup-description">${escapeHtml(point.description)}</p>`;
         }
 
+        // External links
+        if (point.links && point.links.length > 0) {
+            html += '<div class="popup-links">';
+            point.links.forEach(function (link) {
+                const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" fill="${escapeHtml(link.color)}" viewBox="0 0 16 16">${link.svg_paths}</svg>`;
+                html += `<a href="${escapeHtml(link.url)}" target="_blank" rel="noopener noreferrer" class="popup-link-btn" title="${escapeHtml(link.label)}">${svg}</a>`;
+            });
+            html += '</div>';
+        }
+
         // Use original coordinates if available (in case of offset for co-located points)
         const displayLat = point.originalLat !== undefined ? point.originalLat : point.latitude;
         const displayLon = point.originalLon !== undefined ? point.originalLon : point.longitude;

--- a/assets/js/public_map_leaflet.js
+++ b/assets/js/public_map_leaflet.js
@@ -1255,6 +1255,16 @@
             html += `<p class="popup-description">${escapeHtml(point.description)}</p>`;
         }
 
+        // External links
+        if (point.links && point.links.length > 0) {
+            html += '<div class="popup-links">';
+            point.links.forEach(function (link) {
+                const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" fill="${escapeHtml(link.color)}" viewBox="0 0 16 16">${link.svg_paths}</svg>`;
+                html += `<a href="${escapeHtml(link.url)}" target="_blank" rel="noopener noreferrer" class="popup-link-btn" title="${escapeHtml(link.label)}">${svg}</a>`;
+            });
+            html += '</div>';
+        }
+
         // Coordenadas
         html += `<p class="popup-coords">
                     <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="currentColor" class="bi bi-geo-alt me-1" viewBox="0 0 16 16">

--- a/docs/POI_LINKS.md
+++ b/docs/POI_LINKS.md
@@ -1,0 +1,291 @@
+# Links Externos para Puntos de Interés (POI Links)
+
+## Descripción General
+
+Los POI Links permiten asociar links externos tipificados a cada Punto de Interés: sitio web, Google Maps, Instagram, TripAdvisor, Booking, etc. Cada link tiene un tipo enumerado que determina el ícono y el color con el que se renderiza, tanto en el timeline de la página del viaje como en los popups del mapa.
+
+---
+
+## Tipos de Link Soportados
+
+| Tipo           | Label          | Color     |
+|----------------|----------------|-----------|
+| `website`      | Website        | `#0d6efd` |
+| `google_maps`  | Google Maps    | `#ea4335` |
+| `instagram`    | Instagram      | `#c13584` |
+| `facebook`     | Facebook       | `#1877f2` |
+| `twitter`      | Twitter / X    | `#000000` |
+| `tripadvisor`  | TripAdvisor    | `#34e0a1` |
+| `booking`      | Booking.com    | `#003580` |
+| `airbnb`       | Airbnb         | `#ff5a5f` |
+| `youtube`      | YouTube        | `#ff0000` |
+| `other`        | Enlace         | `#6c757d` |
+
+El tipo `other` acepta una etiqueta personalizada (`label`) para casos no cubiertos por los tipos predefinidos.
+
+---
+
+## Arquitectura Técnica
+
+### Base de Datos
+
+**Tabla**: `poi_links`
+
+```sql
+CREATE TABLE poi_links (
+    id          INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    poi_id      INT UNSIGNED NOT NULL,
+    link_type   ENUM('website','google_maps','instagram','facebook',
+                     'twitter','tripadvisor','booking','airbnb','youtube','other')
+                NOT NULL DEFAULT 'website',
+    url         VARCHAR(500) NOT NULL,
+    label       VARCHAR(100) DEFAULT NULL,   -- texto custom (útil para 'other')
+    sort_order  TINYINT UNSIGNED DEFAULT 0,
+    created_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (poi_id) REFERENCES points_of_interest(id) ON DELETE CASCADE
+);
+```
+
+**Decisión de diseño — tabla separada vs columnas en `points_of_interest`:**
+- Un POI puede tener múltiples links del mismo o distinto tipo
+- Evita agregar 10+ columnas nullable a `points_of_interest`
+- Agregar un nuevo tipo en el futuro solo requiere modificar el `ENUM` en la tabla y la constante `TYPES` del modelo
+
+### Modelo PHP
+
+**Archivo**: `src/models/PoiLink.php`
+
+**Métodos públicos:**
+
+| Método | Descripción |
+|--------|-------------|
+| `getByPoiId(int $poi_id): array` | Devuelve todos los links de un POI ordenados por `sort_order` |
+| `replaceForPoi(int $poi_id, array $links): bool` | Reemplaza todos los links (DELETE + INSERT en transacción) |
+| `toApiArray(array $dbRows): array` | Convierte rows de BD a formato JSON para el frontend |
+| `getSvg(string $type, int $size): string` | Genera el SVG inline para un tipo de link |
+| `getTypes(): array` | Devuelve la lista de tipos con su metadata |
+
+**Constante `TYPES`:** define para cada tipo el label, color hexadecimal y los `<path>` SVG (Bootstrap Icons, viewBox 0 0 16 16). Esto permite renderizar íconos sin depender de ninguna fuente de iconos externa.
+
+**Estrategia de guardado `replaceForPoi`:**
+Usa una transacción que primero borra todos los links existentes del POI y luego inserta los nuevos. Esto simplifica la lógica del formulario y garantiza consistencia (no hay links "huérfanos" por reordenamiento).
+
+### API
+
+**Archivo**: `api/get_all_data.php`
+
+Cada POI en la respuesta JSON incluye un campo `links`:
+
+```json
+{
+  "id": 42,
+  "title": "Torre Eiffel",
+  "links": [
+    {
+      "type":      "website",
+      "url":       "https://www.toureiffel.paris",
+      "label":     "Website",
+      "color":     "#0d6efd",
+      "svg_paths": "<path d=\"...\"/>"
+    },
+    {
+      "type":      "google_maps",
+      "url":       "https://maps.google.com/?q=Torre+Eiffel",
+      "label":     "Google Maps",
+      "color":     "#ea4335",
+      "svg_paths": "<path d=\"...\"/>"
+    }
+  ]
+}
+```
+
+Los `svg_paths` son los contenidos internos del `<svg>`, listos para inyectarse en el HTML del popup.
+
+---
+
+## Migración e Instalación
+
+### Opción 1 — Desde el navegador (recomendado)
+
+Navegar a:
+
+```
+http://localhost:8080/TravelMap/install/migrate_poi_links.php
+```
+
+El script verifica si la tabla `poi_links` ya existe antes de ejecutar nada. Si existe, informa y no modifica nada. Si no existe, ejecuta el SQL y muestra la estructura resultante.
+
+### Opción 2 — CLI con MySQL
+
+```bash
+mysql -u root -p travelmap < install/migration_poi_links.sql
+```
+
+### Opción 3 — Docker exec
+
+```bash
+docker exec -i travelmap-db mysql -u root -proot travelmap < install/migration_poi_links.sql
+```
+
+### Opción 4 — PhpMyAdmin
+
+1. Abrir `http://localhost:8081`
+2. Seleccionar la base de datos `travelmap`
+3. Ir a la pestaña **SQL**
+4. Pegar el contenido de `install/migration_poi_links.sql` y ejecutar
+
+### Opción 5 — SQL manual
+
+```sql
+CREATE TABLE IF NOT EXISTS poi_links (
+    id          INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    poi_id      INT UNSIGNED NOT NULL,
+    link_type   ENUM('website','google_maps','instagram','facebook',
+                     'twitter','tripadvisor','booking','airbnb','youtube','other')
+                NOT NULL DEFAULT 'website',
+    url         VARCHAR(500) NOT NULL,
+    label       VARCHAR(100) DEFAULT NULL,
+    sort_order  TINYINT UNSIGNED DEFAULT 0,
+    created_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (poi_id) REFERENCES points_of_interest(id) ON DELETE CASCADE,
+    INDEX idx_poi_id (poi_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+```
+
+> **Nota de seguridad:** después de ejecutar la migración vía browser, considerar restringir o eliminar el archivo `install/migrate_poi_links.php`.
+
+---
+
+## Guía de Uso (Administrador)
+
+### Agregar links a un POI
+
+1. Ir a **Admin → Points of Interest**
+2. Crear un nuevo punto o editar uno existente
+3. En la sección **"Links Externos"**, hacer clic en **"Agregar link"**
+4. Seleccionar el tipo en el dropdown (Website, Google Maps, Instagram, etc.)
+5. Ingresar la URL completa (incluyendo `https://`)
+6. Opcionalmente, ingresar una etiqueta personalizada (solo se muestra en el tooltip)
+7. Repetir para más links
+8. Guardar el formulario
+
+### Reordenar links
+
+El orden de aparición refleja el orden en que se agregaron los links en el formulario. Para reordenar, eliminar y volver a agregar en el orden deseado.
+
+### Eliminar un link
+
+Hacer clic en el botón 🗑️ al final de la fila del link y guardar.
+
+---
+
+## Visualización
+
+### Timeline del viaje (`trip.php`)
+
+Los links aparecen como fila de íconos SVG debajo del nombre del POI en el panel izquierdo. Cada ícono:
+- Tiene el color propio del tipo (rojo para Google Maps, azul para Facebook, etc.)
+- Al pasar el cursor muestra el label en tooltip
+- Abre el link en una pestaña nueva (`target="_blank"`)
+
+### Popup del mapa (MapLibre y Leaflet)
+
+Los links aparecen como una fila de íconos entre la descripción del POI y las coordenadas, con el mismo comportamiento que en el timeline.
+
+---
+
+## Internacionalización
+
+Claves agregadas en `lang/en.json` y `lang/es.json` bajo la sección `points`:
+
+| Clave | Español | Inglés |
+|-------|---------|--------|
+| `points.external_links` | Links Externos | External Links |
+| `points.add_link` | Agregar link | Add link |
+| `points.link_label_optional` | Etiqueta (opcional) | Label (optional) |
+
+---
+
+## Archivos Modificados / Creados
+
+### Backend (PHP)
+| Archivo | Estado |
+|---------|--------|
+| `src/models/PoiLink.php` | NUEVO |
+| `install/migration_poi_links.sql` | NUEVO |
+| `install/migrate_poi_links.php` | NUEVO |
+| `admin/point_form.php` | Modificado |
+| `api/get_all_data.php` | Modificado |
+| `trip.php` | Modificado |
+
+### Frontend (JS / CSS)
+| Archivo | Estado |
+|---------|--------|
+| `assets/js/public_map.js` | Modificado |
+| `assets/js/public_map_leaflet.js` | Modificado |
+| `assets/css/public_map.css` | Modificado |
+| `assets/css/trip.css` | Modificado |
+
+### Internacionalización
+| Archivo | Estado |
+|---------|--------|
+| `lang/en.json` | Modificado |
+| `lang/es.json` | Modificado |
+
+---
+
+## Agregar un Nuevo Tipo de Link
+
+1. Agregar la entrada en la constante `TYPES` de `src/models/PoiLink.php`:
+   ```php
+   'tiktok' => [
+       'label'     => 'TikTok',
+       'color'     => '#010101',
+       'svg_paths' => '<path d="..."/>',
+   ],
+   ```
+2. Agregar `'tiktok'` al `ENUM` en la tabla `poi_links` (migración ALTER TABLE):
+   ```sql
+   ALTER TABLE poi_links
+   MODIFY COLUMN link_type ENUM(
+       'website','google_maps','instagram','facebook',
+       'twitter','tripadvisor','booking','airbnb','youtube','tiktok','other'
+   ) NOT NULL DEFAULT 'website';
+   ```
+3. No hay cambios necesarios en el frontend: el SVG y el color viajan en el JSON de la API.
+
+---
+
+## Solución de Problemas
+
+### Los links no aparecen después de guardar
+
+- Verificar que la migración se ejecutó correctamente (`SHOW TABLES LIKE 'poi_links'`)
+- Verificar que las URLs son válidas (deben incluir `https://`)
+- Revisar los logs de PHP para errores en `PoiLink::replaceForPoi()`
+
+### Error al correr la migración desde el navegador
+
+- Verificar que `config/db.php` tiene las credenciales correctas
+- Si usás Docker, asegurarse de que el contenedor `db` está corriendo: `docker-compose ps`
+- Verificar que el usuario de MySQL tiene permisos de `CREATE TABLE`
+
+### Los íconos no se ven en el mapa
+
+- Verificar que el campo `svg_paths` llega en la respuesta de `api/get_all_data.php`
+- Los SVGs son inline (no dependen de Bootstrap Icons), por lo que no hay dependencias externas que puedan fallar
+- Abrir DevTools → Network → buscar la respuesta de `get_all_data.php` y verificar el campo `links` en los puntos
+
+---
+
+## Compatibilidad
+
+- ✅ **PHP**: 8.0+
+- ✅ **MySQL**: 5.7+ / MariaDB 10.3+
+- ✅ **Navegadores**: Modernos con soporte para `<template>` HTML5 (Chrome 26+, Firefox 22+, Safari 8+)
+- ✅ **MapLibre GL**: v2.x / v3.x
+- ✅ **Leaflet**: v1.x
+
+---
+
+**Última actualización**: Marzo 2026

--- a/install/migrate_poi_links.php
+++ b/install/migrate_poi_links.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Migration: Create poi_links table
+ *
+ * Run this script ONCE from your browser:
+ * http://localhost/TravelMap/install/migrate_poi_links.php
+ *
+ * After execution, delete or protect this file.
+ */
+
+require_once __DIR__ . '/../config/db.php';
+
+header('Content-Type: text/html; charset=utf-8');
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Migration - POI Links</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            max-width: 800px;
+            margin: 40px auto;
+            padding: 20px;
+            background: #f5f5f5;
+        }
+        .container {
+            background: white;
+            padding: 30px;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+        h1 { color: #333; border-bottom: 3px solid #007bff; padding-bottom: 10px; }
+        .success { background: #d4edda; color: #155724; padding: 12px; border-radius: 4px; border-left: 4px solid #28a745; margin: 15px 0; }
+        .error   { background: #f8d7da; color: #721c24; padding: 12px; border-radius: 4px; border-left: 4px solid #dc3545; margin: 15px 0; }
+        .info    { background: #d1ecf1; color: #0c5460; padding: 12px; border-radius: 4px; border-left: 4px solid #17a2b8; margin: 15px 0; }
+        table    { border-collapse: collapse; width: 100%; }
+        th, td   { border: 1px solid #dee2e6; padding: 6px 10px; }
+        th       { background: #f8f9fa; }
+    </style>
+</head>
+<body>
+<div class="container">
+    <h1>🔗 Migration: POI Links</h1>
+
+    <div class="info">
+        <strong>ℹ️ Information:</strong> This script creates the <code>poi_links</code> table,
+        which stores typed external links (website, Google Maps, Instagram, etc.) for each Point of Interest.
+    </div>
+
+<?php
+
+try {
+    $conn = getDB();
+
+    echo "<h3>Checking database status...</h3>";
+
+    // Check if table already exists
+    $stmt  = $conn->query("SHOW TABLES LIKE 'poi_links'");
+    $exists = $stmt->rowCount() > 0;
+
+    if ($exists) {
+        echo '<div class="info">';
+        echo '<strong>✓ Table <code>poi_links</code> already exists.</strong><br>';
+        echo 'No changes were made.';
+        echo '</div>';
+    } else {
+        echo "<p>Creating table <code>poi_links</code>...</p>";
+
+        $sqlFile = __DIR__ . '/migration_poi_links.sql';
+        if (!file_exists($sqlFile)) {
+            throw new Exception("Migration SQL file not found: " . basename($sqlFile));
+        }
+
+        $conn->exec(file_get_contents($sqlFile));
+
+        echo '<div class="success">';
+        echo '<strong>✓ Table <code>poi_links</code> created successfully!</strong>';
+        echo '</div>';
+    }
+
+    // Show current table structure
+    echo "<h3>Table Structure:</h3>";
+    $columns = $conn->query("DESCRIBE poi_links")->fetchAll(PDO::FETCH_ASSOC);
+
+    echo "<table>";
+    echo "<tr><th>Field</th><th>Type</th><th>Null</th><th>Key</th><th>Default</th></tr>";
+    foreach ($columns as $col) {
+        echo "<tr>";
+        echo "<td><b>{$col['Field']}</b></td>";
+        echo "<td>{$col['Type']}</td>";
+        echo "<td>{$col['Null']}</td>";
+        echo "<td>{$col['Key']}</td>";
+        echo "<td>" . ($col['Default'] ?? '<em>NULL</em>') . "</td>";
+        echo "</tr>";
+    }
+    echo "</table>";
+
+} catch (PDOException $e) {
+    echo '<div class="error"><strong>❌ Database Error:</strong><br>' . htmlspecialchars($e->getMessage()) . '</div>';
+} catch (Exception $e) {
+    echo '<div class="error"><strong>❌ Error:</strong><br>' . htmlspecialchars($e->getMessage()) . '</div>';
+}
+
+?>
+
+    <p style="margin-top: 30px;">
+        <a href="../index.php" style="background: #007bff; color: white; padding: 10px 20px; text-decoration: none; border-radius: 4px;">Go to Home</a>
+    </p>
+</div>
+</body>
+</html>

--- a/install/migration_poi_links.sql
+++ b/install/migration_poi_links.sql
@@ -1,0 +1,26 @@
+-- Migration: Create poi_links table
+-- Description: Adds typed external links to points of interest (website, social media, maps, etc.)
+-- Date: 2026-03-30
+
+CREATE TABLE IF NOT EXISTS poi_links (
+    id          INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    poi_id      INT UNSIGNED NOT NULL,
+    link_type   ENUM(
+                    'website',
+                    'google_maps',
+                    'instagram',
+                    'facebook',
+                    'twitter',
+                    'tripadvisor',
+                    'booking',
+                    'airbnb',
+                    'youtube',
+                    'other'
+                ) NOT NULL DEFAULT 'website',
+    url         VARCHAR(500) NOT NULL,
+    label       VARCHAR(100) DEFAULT NULL,
+    sort_order  TINYINT UNSIGNED DEFAULT 0,
+    created_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (poi_id) REFERENCES points_of_interest(id) ON DELETE CASCADE,
+    INDEX idx_poi_id (poi_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/lang/en.json
+++ b/lang/en.json
@@ -306,7 +306,10 @@
     "copy_coordinates_manually": "and copy coordinates manually.",
     "invalid_image_format": "Please select a valid image (JPG, JPEG, PNG or GIF)",
     "file_too_large": "File is too large. Maximum size is",
-    "point_info": "Point Information"
+    "point_info": "Point Information",
+    "external_links": "External Links",
+    "add_link": "Add link",
+    "link_label_optional": "Label (optional)"
   },
   "routes": {
     "title": "Routes",

--- a/lang/es.json
+++ b/lang/es.json
@@ -306,7 +306,10 @@
     "copy_coordinates_manually": "y copiar las coordenadas manualmente.",
     "invalid_image_format": "Por favor, selecciona una imagen válida (JPG, JPEG, PNG o GIF)",
     "file_too_large": "El archivo es demasiado grande. El tamaño máximo es",
-    "point_info": "Información del Punto"
+    "point_info": "Información del Punto",
+    "external_links": "Links Externos",
+    "add_link": "Agregar link",
+    "link_label_optional": "Etiqueta (opcional)"
   },
   "routes": {
     "title": "Rutas",

--- a/src/models/PoiLink.php
+++ b/src/models/PoiLink.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Modelo: PoiLink
+ *
+ * Gestiona los links externos asociados a puntos de interés
+ */
+
+class PoiLink {
+    private $db;
+
+    // Tipos de link soportados con metadata para UI
+    // svg: path(s) dentro de un viewBox="0 0 16 16" (Bootstrap Icons style)
+    const TYPES = [
+        'website'     => ['label' => 'Website',      'color' => '#0d6efd', 'svg_paths' => '<path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8m7.5-6.923c-.67.204-1.335.82-1.887 1.855A8 8 0 0 0 5.145 4H7.5zM4.09 4a9.3 9.3 0 0 1 .64-1.539 7 7 0 0 1 .597-.933A7.03 7.03 0 0 0 2.255 4zm-.582 3.5c.03-.877.138-1.718.312-2.5H1.674a7 7 0 0 0-.656 2.5zM4.847 5a12.5 12.5 0 0 0-.338 2.5H7.5V5zM8.5 5v2.5h2.99a12.5 12.5 0 0 0-.337-2.5zM4.51 8.5a12.5 12.5 0 0 0 .337 2.5H7.5V8.5zm3.99 0V11h2.653c.187-.765.306-1.608.338-2.5zM5.145 12q.208.58.468 1.068c.552 1.035 1.218 1.65 1.887 1.855V12zm.182 2.472a7 7 0 0 1-.597-.933A9.3 9.3 0 0 1 4.09 12H2.255a7 7 0 0 0 3.072 2.472M3.82 11a13.7 13.7 0 0 1-.312-2.5h-2.49c.062.89.291 1.733.656 2.5zm6.853 3.472A7 7 0 0 0 13.745 12H11.91a9.3 9.3 0 0 1-.64 1.539 7 7 0 0 1-.597.933M8.5 12v2.923c.67-.204 1.335-.82 1.887-1.855q.26-.487.468-1.068zm3.68-1h2.146c.365-.767.594-1.61.656-2.5h-2.49a13.7 13.7 0 0 1-.312 2.5m2.802-3.5a7 7 0 0 0-.656-2.5H12.18c.174.782.282 1.623.312 2.5zM11.27 2.461c.247.464.462.98.64 1.539h1.835a7 7 0 0 0-3.072-2.472c.218.284.418.598.597.933M10.855 4a8 8 0 0 0-.468-1.068C9.835 1.897 9.17 1.282 8.5 1.077V4z"/>'],
+        'google_maps' => ['label' => 'Google Maps',  'color' => '#ea4335', 'svg_paths' => '<path d="M8 16s6-5.686 6-10A6 6 0 0 0 2 6c0 4.314 6 10 6 10m0-7a3 3 0 1 1 0-6 3 3 0 0 1 0 6"/>'],
+        'instagram'   => ['label' => 'Instagram',    'color' => '#c13584', 'svg_paths' => '<path d="M8 0C5.829 0 5.556.01 4.703.048 3.85.088 3.269.222 2.76.42a3.9 3.9 0 0 0-1.417.923A3.9 3.9 0 0 0 .42 2.76C.222 3.268.087 3.85.048 4.7.01 5.555 0 5.827 0 8.001c0 2.172.01 2.444.048 3.297.04.852.174 1.433.372 1.942.205.526.478.972.923 1.417.444.445.89.719 1.416.923.51.198 1.09.333 1.942.372C5.555 15.99 5.827 16 8 16s2.444-.01 3.298-.048c.851-.04 1.434-.174 1.943-.372a3.9 3.9 0 0 0 1.416-.923c.445-.445.718-.891.923-1.417.197-.509.332-1.09.372-1.942C15.99 10.445 16 10.173 16 8s-.01-2.445-.048-3.299c-.04-.851-.175-1.433-.372-1.941a3.9 3.9 0 0 0-.923-1.417A3.9 3.9 0 0 0 13.24.42c-.51-.198-1.092-.333-1.943-.372C10.443.01 10.172 0 7.998 0zm-.717 1.442h.718c2.136 0 2.389.007 3.232.046.78.035 1.204.166 1.486.275.373.145.64.319.92.599s.453.546.598.92c.11.281.24.705.275 1.485.039.843.047 1.096.047 3.231s-.008 2.389-.047 3.232c-.035.78-.166 1.203-.275 1.485a2.5 2.5 0 0 1-.599.919c-.28.28-.546.453-.92.598-.28.11-.704.24-1.485.276-.843.038-1.096.047-3.232.047s-2.39-.009-3.233-.047c-.78-.036-1.203-.166-1.485-.276a2.5 2.5 0 0 1-.92-.598 2.5 2.5 0 0 1-.6-.92c-.109-.281-.24-.705-.275-1.485-.038-.843-.046-1.096-.046-3.233s.008-2.388.046-3.231c.036-.78.166-1.204.276-1.486.145-.373.319-.64.599-.92s.546-.453.92-.598c.282-.11.705-.24 1.485-.276.738-.034 1.024-.044 2.515-.045zm4.988 1.328a.96.96 0 1 0 0 1.92.96.96 0 0 0 0-1.92m-4.27 1.122a4.109 4.109 0 1 0 0 8.217 4.109 4.109 0 0 0 0-8.217m0 1.441a2.667 2.667 0 1 1 0 5.334 2.667 2.667 0 0 1 0-5.334"/>'],
+        'facebook'    => ['label' => 'Facebook',     'color' => '#1877f2', 'svg_paths' => '<path d="M16 8.049c0-4.446-3.582-8.05-8-8.05C3.58 0-.002 3.603-.002 8.05c0 4.017 2.926 7.347 6.75 7.951v-5.625h-2.03V8.05H6.75V6.275c0-2.017 1.195-3.131 3.022-3.131.876 0 1.791.157 1.791.157v1.98h-1.009c-.993 0-1.303.621-1.303 1.258v1.51h2.218l-.354 2.326H9.25V16c3.824-.604 6.75-3.934 6.75-7.951"/>'],
+        'twitter'     => ['label' => 'Twitter / X',  'color' => '#000000', 'svg_paths' => '<path d="M12.6.75h2.454l-5.36 6.142L16 15.25h-4.937l-3.867-5.07-4.425 5.07H.316l5.733-6.57L0 .75h5.063l3.495 4.633L12.601.75Zm-.86 13.028h1.36L4.323 2.145H2.865z"/>'],
+        'tripadvisor' => ['label' => 'TripAdvisor',  'color' => '#34e0a1', 'svg_paths' => '<path d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3"/><path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8m8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13"/>'],
+        'booking'     => ['label' => 'Booking.com',  'color' => '#003580', 'svg_paths' => '<path d="M2 2a2 2 0 0 0-2 2v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2zm1 2h10a1 1 0 0 1 1 1v6a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1"/>'],
+        'airbnb'      => ['label' => 'Airbnb',       'color' => '#ff5a5f', 'svg_paths' => '<path d="M8 0C3.584 0 0 3.584 0 8s3.584 8 8 8 8-3.584 8-8-3.584-8-8-8m0 4a4 4 0 1 1 0 8 4 4 0 0 1 0-8m0 1.5a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5"/>'],
+        'youtube'     => ['label' => 'YouTube',      'color' => '#ff0000', 'svg_paths' => '<path d="M8.051 1.999h.089c.822.003 4.987.033 6.11.335a2.01 2.01 0 0 1 1.415 1.42c.101.38.172.883.22 1.402l.01.104.022.26.008.104c.065.914.073 1.77.074 1.957v.075c-.001.194-.01 1.108-.082 2.06l-.008.105-.009.104c-.05.572-.124 1.14-.235 1.558a2.01 2.01 0 0 1-1.415 1.42c-1.16.312-5.569.334-6.18.335h-.142c-.309 0-1.587-.006-2.927-.052l-.17-.006-.087-.004-.171-.007-.171-.007c-1.11-.049-2.167-.128-2.654-.26a2.01 2.01 0 0 1-1.415-1.419c-.111-.417-.185-.986-.235-1.558L.09 9.82l-.008-.104A31 31 0 0 1 0 7.68v-.123c.002-.215.01-.958.064-1.778l.007-.103.003-.052.008-.104.022-.26.01-.104c.048-.519.119-1.023.22-1.402a2.01 2.01 0 0 1 1.415-1.42c.487-.13 1.544-.21 2.654-.26l.17-.007.172-.006.086-.003.171-.007A100 100 0 0 1 7.858 2zM6.4 5.209v4.818l4.157-2.408z"/>'],
+        'other'       => ['label' => 'Enlace',       'color' => '#6c757d', 'svg_paths' => '<path d="M4.715 6.542 3.343 7.914a3 3 0 1 0 4.243 4.243l1.828-1.829A3 3 0 0 0 8.586 5.5L8 6.086a1 1 0 0 0-.154.199 2 2 0 0 1 .861 3.337L6.88 11.45a2 2 0 1 1-2.83-2.83l.793-.792a4 4 0 0 1-.128-1.287z"/><path d="M6.586 4.672A3 3 0 0 0 7.414 9.5l.775-.776a2 2 0 0 1-.896-3.346L9.12 3.55a2 2 0 1 1 2.83 2.83l-.793.792c.112.42.155.855.128 1.287l1.372-1.372a3 3 0 1 0-4.243-4.243z"/>'],
+    ];
+
+    public function __construct() {
+        $this->db = getDB();
+    }
+
+    /**
+     * Obtener todos los links de un POI
+     */
+    public function getByPoiId(int $poi_id): array {
+        try {
+            $stmt = $this->db->prepare(
+                'SELECT * FROM poi_links WHERE poi_id = ? ORDER BY sort_order ASC, id ASC'
+            );
+            $stmt->execute([$poi_id]);
+            return $stmt->fetchAll();
+        } catch (PDOException $e) {
+            error_log('Error al obtener links del POI: ' . $e->getMessage());
+            return [];
+        }
+    }
+
+    /**
+     * Reemplaza todos los links de un POI (delete + insert)
+     *
+     * @param int   $poi_id
+     * @param array $links  Array de ['link_type'=>..., 'url'=>..., 'label'=>..., 'sort_order'=>...]
+     */
+    public function replaceForPoi(int $poi_id, array $links): bool {
+        try {
+            $this->db->beginTransaction();
+
+            $this->db->prepare('DELETE FROM poi_links WHERE poi_id = ?')->execute([$poi_id]);
+
+            if (!empty($links)) {
+                $stmt = $this->db->prepare(
+                    'INSERT INTO poi_links (poi_id, link_type, url, label, sort_order)
+                     VALUES (?, ?, ?, ?, ?)'
+                );
+                foreach ($links as $i => $link) {
+                    $type = $link['link_type'] ?? 'other';
+                    if (!array_key_exists($type, self::TYPES)) {
+                        $type = 'other';
+                    }
+                    $url = trim($link['url'] ?? '');
+                    if ($url === '') continue;
+
+                    $stmt->execute([
+                        $poi_id,
+                        $type,
+                        $url,
+                        trim($link['label'] ?? '') ?: null,
+                        (int) ($link['sort_order'] ?? $i),
+                    ]);
+                }
+            }
+
+            $this->db->commit();
+            return true;
+        } catch (PDOException $e) {
+            $this->db->rollBack();
+            error_log('Error al guardar links del POI: ' . $e->getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Convierte los links de BD en array JSON-friendly para el frontend
+     */
+    public static function toApiArray(array $dbRows): array {
+        return array_map(function ($row) {
+            $meta = self::TYPES[$row['link_type']] ?? self::TYPES['other'];
+            return [
+                'type'      => $row['link_type'],
+                'url'       => $row['url'],
+                'label'     => $row['label'] ?: $meta['label'],
+                'color'     => $meta['color'],
+                'svg_paths' => $meta['svg_paths'],
+            ];
+        }, $dbRows);
+    }
+
+    /**
+     * Genera el SVG inline para un tipo de link
+     */
+    public static function getSvg(string $type, int $size = 16): string {
+        $meta = self::TYPES[$type] ?? self::TYPES['other'];
+        return sprintf(
+            '<svg xmlns="http://www.w3.org/2000/svg" width="%d" height="%d" fill="%s" viewBox="0 0 16 16">%s</svg>',
+            $size, $size, htmlspecialchars($meta['color']), $meta['svg_paths']
+        );
+    }
+
+    /**
+     * Devuelve los tipos disponibles (para formularios)
+     */
+    public static function getTypes(): array {
+        return self::TYPES;
+    }
+}

--- a/trip.php
+++ b/trip.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/src/models/Trip.php';
 require_once __DIR__ . '/src/models/Route.php';
 require_once __DIR__ . '/src/models/Point.php';
 require_once __DIR__ . '/src/models/TripTag.php';
+require_once __DIR__ . '/src/models/PoiLink.php';
 require_once __DIR__ . '/src/helpers/FileHelper.php';
 require_once __DIR__ . '/src/models/Settings.php';
 
@@ -25,10 +26,11 @@ if (!isset($_GET['id']) || !is_numeric($_GET['id'])) {
 $tripId = (int)$_GET['id'];
 $db = getDB();
 
-$tripModel = new Trip();
-$routeModel = new Route();
-$pointModel = new Point();
+$tripModel    = new Trip();
+$routeModel   = new Route();
+$pointModel   = new Point();
 $tripTagModel = new TripTag();
+$poiLinkModel = new PoiLink();
 
 $trip = $tripModel->getById($tripId);
 
@@ -71,6 +73,8 @@ foreach ($points as $point) {
         $thumbnail_url = $thumb_path ? BASE_URL . '/' . $thumb_path : null;
     }
     
+    $links = PoiLink::toApiArray($poiLinkModel->getByPoiId((int) $point['id']));
+
     $processedPoints[] = [
         'id' => (int) $point['id'],
         'title' => $point['title'],
@@ -80,7 +84,8 @@ foreach ($points as $point) {
         'longitude' => (float) $point['longitude'],
         'image_url' => !empty($point['image_path']) ? BASE_URL . '/' . $point['image_path'] : null,
         'thumbnail_url' => $thumbnail_url,
-        'visit_date' => $point['visit_date']
+        'visit_date' => $point['visit_date'],
+        'links' => $links,
     ];
 }
 
@@ -197,9 +202,24 @@ $statsIcons = [
                         <div class="timeline-point" data-id="<?= $point['id'] ?>" data-lat="<?= $point['latitude'] ?>" data-lng="<?= $point['longitude'] ?>">
                             <div class="point-marker"></div>
                             <div class="point-content">
-                                <h3 class="point-title"><?= htmlspecialchars($point['title']) ?></h3>
-                                <?php if ($point['visit_date']): ?>
-                                    <span class="point-date"><?= date('d M Y', strtotime($point['visit_date'])) ?></span>
+                                <div class="point-header">
+                                    <h3 class="point-title"><?= htmlspecialchars($point['title']) ?></h3>
+                                    <?php if ($point['visit_date']): ?>
+                                        <span class="point-date"><?= date('d M Y', strtotime($point['visit_date'])) ?></span>
+                                    <?php endif; ?>
+                                </div>
+                                <?php if (!empty($point['links'])): ?>
+                                <div class="point-links">
+                                    <?php foreach ($point['links'] as $link): ?>
+                                    <a href="<?= htmlspecialchars($link['url']) ?>"
+                                       target="_blank"
+                                       rel="noopener noreferrer"
+                                       class="point-link-btn"
+                                       title="<?= htmlspecialchars($link['label']) ?>">
+                                        <?= PoiLink::getSvg($link['type'], 14) ?>
+                                    </a>
+                                    <?php endforeach; ?>
+                                </div>
                                 <?php endif; ?>
                             </div>
                         </div>


### PR DESCRIPTION
- New `poi_links` table with 10 enumerated types (website, google_maps, instagram, facebook, twitter, tripadvisor, booking, airbnb, youtube, other)
- PoiLink model with replaceForPoi (transactional delete+insert), toApiArray and inline SVG helpers — no external icon font dependency
- Admin point_form: dynamic add/remove link rows via <template>
- api/get_all_data.php and trip.php: include links array per POI
- Trip timeline and map popups (MapLibre + Leaflet): render colored SVG icon buttons linking to external URLs
- Migration: install/migration_poi_links.sql + install/migrate_poi_links.php (idempotent — skips if table already exists)
- Docs: docs/POI_LINKS.md with 5 migration options and usage guide
- i18n: added points.external_links, points.add_link, points.link_label_optional