### PR TITLE
Enable toggle for legend items visibility

### DIFF
--- a/assets/js/public_map.js
+++ b/assets/js/public_map.js
@@ -917,6 +917,10 @@
         if (legendItems.length === 0) return;
 
         legendItems.empty();
+        //permite que se pueda ocultar y mostrar el listado de leyendas.
+        legendItems.prev().on('click', function () {
+            legendItems.toggle(200);
+        });
 
         const transportOrder = [
             { type: 'plane', icon: transportIcons.plane, label: __('map.transport_plane') },


### PR DESCRIPTION
Added functionality to toggle visibility of legend items.
Click in tltle for toggle. 

Se agregó funcionalidad para alternar la visibilidad de los elementos de la leyenda.
Haga clic en Ttle para alternar.