### PR TITLE
Fix routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.0.240] – 2026-04-13
+- Modelo Route: nuevos campos `name`, `description`, `image_path` en `create()` y `update()`
+- Nuevo modelo `RouteLink` para links externos tipificados en rutas (paralelo a `PoiLink`)
+- API `get_all_data.php`: incluye nuevos campos de ruta y links en el response
+- Editor de rutas (`trip_edit_map.php`): campos para nombre y descripción de rutas con modal de edición
+- Mapa público (MapLibre y Leaflet): popups de rutas muestran nombre y descripción si existen
+- Migración 019: nuevos campos `start_datetime` y `end_datetime` en tabla routes
+- Editor de rutas: campos de fecha/hora de inicio y fin del trayecto
+
 ## [1.0.230] – 2026-04-13
 - Toggle de caja de leyenda
 

--- a/admin/trip_edit_map.php
+++ b/admin/trip_edit_map.php
@@ -16,10 +16,12 @@ require_once __DIR__ . '/../config/db.php';
 require_once __DIR__ . '/../src/models/Trip.php';
 require_once __DIR__ . '/../src/models/Route.php';
 require_once __DIR__ . '/../src/models/Point.php';
+require_once __DIR__ . '/../src/models/RouteLink.php';
 
 $tripModel = new Trip();
 $routeModel = new Route();
 $pointModel = new Point();
+$routeLinkModel = new RouteLink();
 $message = '';
 $message_type = '';
 
@@ -50,13 +52,22 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['routes_data'])) {
             
             // Crear nuevas rutas
             foreach ($routes_array as $route_data) {
-                $routeModel->create([
+                $route_id = $routeModel->create([
                     'trip_id' => $trip_id,
                     'transport_type' => $route_data['transport_type'] ?? 'car',
                     'geojson_data' => json_encode($route_data['geojson']),
                     'is_round_trip' => $route_data['is_round_trip'] ?? 0,
-                    'color' => $route_data['color'] ?? Route::getColorByTransport($route_data['transport_type'] ?? 'car')
+                    'color' => $route_data['color'] ?? Route::getColorByTransport($route_data['transport_type'] ?? 'car'),
+                    'name' => $route_data['name'] ?? null,
+                    'description' => $route_data['description'] ?? null,
+                    'start_datetime' => !empty($route_data['start_datetime']) ? date('Y-m-d H:i:s', strtotime($route_data['start_datetime'])) : null,
+                    'end_datetime' => !empty($route_data['end_datetime']) ? date('Y-m-d H:i:s', strtotime($route_data['end_datetime'])) : null
                 ]);
+                
+                // Guardar links de la ruta
+                if ($route_id && !empty($route_data['links']) && is_array($route_data['links'])) {
+                    $routeLinkModel->replaceForRoute($route_id, $route_data['links']);
+                }
             }
             
             $message = __('routes.saved_success');
@@ -87,7 +98,18 @@ foreach ($routes as $route) {
         'transport_type' => $route['transport_type'],
         'geojson' => json_decode($route['geojson_data'], true),
         'is_round_trip' => (int)$route['is_round_trip'],
-        'color' => $route['color']
+        'color' => $route['color'],
+        'name' => $route['name'] ?? '',
+        'description' => $route['description'] ?? '',
+        'start_datetime' => $route['start_datetime'] ?? '',
+        'end_datetime' => $route['end_datetime'] ?? '',
+        'links' => array_map(function($lnk) {
+            return [
+                'type' => $lnk['link_type'],
+                'url' => $lnk['url'],
+                'label' => $lnk['label'] ?? ''
+            ];
+        }, $routeLinkModel->getByRouteId((int)$route['id']))
     ];
 }
 
@@ -304,6 +326,8 @@ const tripColor = '<?= htmlspecialchars($trip['color_hex']) ?>';
 const existingRoutes = <?= json_encode($routes_js) ?>;
 const existingPoints = <?= json_encode($points_js) ?>;
 const transportTypes = <?= json_encode($transport_types) ?>;
+const routeLinkTypes = <?= json_encode(RouteLink::getTypes()) ?>;
+window.routeLinkTypes = routeLinkTypes;
 
 // Traducciones para JS
 const PHP_TRANSLATIONS = <?= $lang->getTranslationsAsJson() ?>;

--- a/api/get_all_data.php
+++ b/api/get_all_data.php
@@ -14,14 +14,16 @@ require_once __DIR__ . '/../src/models/Route.php';
 require_once __DIR__ . '/../src/models/Point.php';
 require_once __DIR__ . '/../src/models/TripTag.php';
 require_once __DIR__ . '/../src/models/PoiLink.php';
+require_once __DIR__ . '/../src/models/RouteLink.php';
 require_once __DIR__ . '/../src/helpers/FileHelper.php';
 
 try {
-    $tripModel    = new Trip();
-    $routeModel   = new Route();
-    $pointModel   = new Point();
-    $tripTagModel = new TripTag();
-    $poiLinkModel = new PoiLink();
+    $tripModel      = new Trip();
+    $routeModel     = new Route();
+    $pointModel     = new Point();
+    $tripTagModel   = new TripTag();
+    $poiLinkModel   = new PoiLink();
+    $routeLinkModel = new RouteLink();
     
     // Obtener todos los viajes publicados
     $trips = $tripModel->getAll('start_date DESC', 'published');
@@ -47,13 +49,30 @@ try {
             $dist = (int) ($route['distance_meters'] ?? 0);
             $totalDistance += $dist;
             
+            // Obtener links de la ruta
+            $links = RouteLink::toApiArray($routeLinkModel->getByRouteId((int) $route['id']));
+            
+            // Obtener thumbnail si existe
+            $thumbnail_url = null;
+            if (!empty($route['image_path'])) {
+                $thumb_path = FileHelper::getThumbnailPath($route['image_path']);
+                $thumbnail_url = $thumb_path ? BASE_URL . '/' . $thumb_path : null;
+            }
+            
             $processedRoutes[] = [
                 'id' => (int) $route['id'],
                 'transport_type' => $route['transport_type'],
                 'color' => $route['color'],
                 'distance_meters' => $dist,
                 'is_round_trip' => (bool) ($route['is_round_trip'] ?? false),
-                'geojson' => json_decode($route['geojson_data'], true)
+                'geojson' => json_decode($route['geojson_data'], true),
+                'name' => $route['name'] ?? null,
+                'description' => $route['description'] ?? null,
+                'image_url' => !empty($route['image_path']) ? BASE_URL . '/' . $route['image_path'] : null,
+                'thumbnail_url' => $thumbnail_url,
+                'start_datetime' => $route['start_datetime'] ?? null,
+                'end_datetime' => $route['end_datetime'] ?? null,
+                'links' => $links,
             ];
         }
         

--- a/assets/css/trip.css
+++ b/assets/css/trip.css
@@ -237,6 +237,79 @@ body.trip-page {
     border-radius: 2px;
 }
 
+/* ========== Routes Timeline ========== */
+.trip-routes-timeline {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.timeline-routes {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.timeline-route-item {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.625rem;
+    padding: 0.5rem 0.75rem;
+    background: #f8fafc;
+    border-radius: 0.5rem;
+    border: 1px solid #e2e8f0;
+}
+
+.route-color-dot {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    margin-top: 0.35rem;
+    box-shadow: 0 0 0 2px white, 0 1px 3px rgba(0,0,0,0.15);
+}
+
+.route-content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    flex: 1;
+    min-width: 0;
+}
+
+.route-name {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: #1e293b;
+    line-height: 1.3;
+}
+
+.route-datetime {
+    font-size: 0.75rem;
+    color: #64748b;
+}
+
+.route-description {
+    font-size: 0.8125rem;
+    color: #64748b;
+    line-height: 1.5;
+    max-height: 3.5rem;
+    overflow-y: auto;
+}
+
+/* Route item in unified timeline */
+.timeline-point.timeline-route {
+    background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%);
+    border: 1px solid #e2e8f0;
+}
+
+.timeline-point.timeline-route .point-marker {
+    background-color: var(--trip-color, #3b82f6);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
 /* ========== Timeline ========== */
 .timeline-heading {
     font-size: 0.7rem;

--- a/assets/js/public_map.js
+++ b/assets/js/public_map.js
@@ -271,6 +271,61 @@
     }
 
     /**
+     * Formatea fecha/hora de inicio y fin de ruta
+     */
+    function formatRouteDatetime(start, end) {
+        const isValid = (v) => v && v !== 'null' && v !== 'undefined' && v !== '';
+        if (!isValid(start) && !isValid(end)) return '';
+        
+        const opts = { day: '2-digit', month: 'short' };
+        const timeOpts = { hour: '2-digit', minute: '2-digit' };
+        const locale = document.documentElement.lang || 'es-ES';
+        
+        const parseDate = (dt) => {
+            if (!isValid(dt)) return null;
+            let d = new Date(dt);
+            if (!isNaN(d.getTime())) return d;
+            d = new Date(dt.replace(' ', 'T'));
+            if (!isNaN(d.getTime())) return d;
+            const parts = dt.match(/(\d{4})-(\d{2})-(\d{2})\s*(\d{2}):?(\d{2})?/);
+            if (parts) {
+                return new Date(parts[1], parts[2] - 1, parts[3], parts[4] || 0, parts[5] || 0);
+            }
+            return null;
+        };
+        
+        const formatDate = (dt) => {
+            const d = parseDate(dt);
+            if (!d) return '';
+            return d.toLocaleDateString(locale, opts);
+        };
+        
+        const formatTime = (dt) => {
+            const d = parseDate(dt);
+            if (!d) return '';
+            return d.toLocaleTimeString(locale, timeOpts);
+        };
+        
+        const startDate = formatDate(start);
+        const startTime = formatTime(start);
+        const endDate = formatDate(end);
+        const endTime = formatTime(end);
+        
+        if (startDate && startTime && endDate && endTime) {
+            return `${startDate} ${startTime} - ${endTime}`;
+        } else if (startDate && startTime) {
+            return `${startDate} ${startTime}`;
+        } else if (startDate) {
+            return startDate;
+        } else if (endDate && endTime) {
+            return `${endDate} ${endTime}`;
+        } else if (endDate) {
+            return endDate;
+        }
+        return '';
+    }
+
+    /**
      * Initialize the MapLibre GL map
      */
     function initMap() {
@@ -527,10 +582,26 @@
                     tagsHtml += '</div>';
                 }
 
+                let linksHtml = '';
+                if (route.links && route.links.length > 0) {
+                    linksHtml = '<div class="mt-1 d-flex gap-1 flex-wrap">';
+                    route.links.forEach(link => {
+                        const color = link.color || '#6c757d';
+                        const svgPaths = link.svg_paths || '<path d="M4.715 6.542 3.343 7.914a3 3 0 1 0 4.243 4.243l1.828-1.829A3 3 0 0 0 8.586 5.5L8 6.086a1 1 0 0 0-.154.199 2 2 0 0 1 .861 3.337L6.88 11.45a2 2 0 1 1-2.83-2.83l.793-.792a4 4 0 0 1-.128-1.287z"/><path d="M6.586 4.672A3 3 0 0 0 7.414 9.5l.775-.776a2 2 0 0 1-.896-3.346L9.12 3.55a2 2 0 1 1 2.83 2.83l-.793.792c.112.42.155.855.128 1.287l1.372-1.372a3 3 0 1 0-4.243-4.243z"/>';
+                        const label = link.label || link.type || 'Link';
+                        linksHtml += `<a href="${escapeHtml(link.url)}" target="_blank" class="text-decoration-none" title="${escapeHtml(label)}"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="${color}" viewBox="0 0 16 16">${svgPaths}</svg></a>`;
+                    });
+                    linksHtml += '</div>';
+                }
+
                 popup.setLngLat(e.lngLat)
                     .setHTML(`
                         <div class="route-popup">
                             <strong>${config.icon} ${escapeHtml(trip.title)}</strong>${appConfig?.tripPageEnabled ? ` <a href="trip.php?id=${trip.id}" target="_blank" class="ms-1 text-muted text-decoration-none" title="${__('map.view_trip_details')}"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="currentColor" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M8.636 3.5a.5.5 0 0 0-.5-.5H1.5A1.5 1.5 0 0 0 0 4.5v10A1.5 1.5 0 0 0 1.5 16h10a1.5 1.5 0 0 0 1.5-1.5V7.864a.5.5 0 0 0-1 0V14.5a.5.5 0 0 1-.5.5h-10a.5.5 0 0 1-.5-.5v-10a.5.5 0 0 1 .5-.5h6.636a.5.5 0 0 0 .5-.5"/><path fill-rule="evenodd" d="M16 .5a.5.5 0 0 0-.5-.5h-5a.5.5 0 0 0 0 1h3.793L6.146 9.146a.5.5 0 1 0 .708.708L15 1.707V5.5a.5.5 0 0 0 1 0z"/></svg></a>` : ''}${futureLabel}
+                            ${route.name ? `<br><small class="text-primary fw-bold">${escapeHtml(route.name)}</small>` : ''}
+                            ${(route.start_datetime && route.start_datetime !== 'null') || (route.end_datetime && route.end_datetime !== 'null') ? `<br><small class="text-secondary">${formatRouteDatetime(route.start_datetime, route.end_datetime)}</small>` : ''}
+                            ${route.description ? `<br><small class="text-muted">${escapeHtml(route.description)}</small>` : ''}
+                            ${linksHtml}
                             ${tagsHtml}
                             <br>
                             <small class="text-muted">${__('map.transport')}: ${__('map.transport_' + transportType)}${formatDistance(route.distance_meters, transportType, route.is_round_trip)}</small>
@@ -600,6 +671,11 @@
                                 target: coords[1],
                                 tripId: trip.id,
                                 tripTitle: trip.title,
+                                routeName: route.name || '',
+                                routeDescription: route.description || '',
+                                startDatetime: route.start_datetime || '',
+                                endDatetime: route.end_datetime || '',
+                                routeLinks: route.links || [],
                                 isFuture: isFuture,
                                 distanceMeters: route.distance_meters,
                                 isRoundTrip: route.is_round_trip,
@@ -649,10 +725,26 @@
                         tagsHtml += '</div>';
                     }
 
+                    let linksHtml = '';
+                    if (d.routeLinks && d.routeLinks.length > 0) {
+                        linksHtml = '<div class="mt-1 d-flex gap-1 flex-wrap">';
+                        d.routeLinks.forEach(link => {
+                            const color = link.color || '#6c757d';
+                            const svgPaths = link.svg_paths || '<path d="M4.715 6.542 3.343 7.914a3 3 0 1 0 4.243 4.243l1.828-1.829A3 3 0 0 0 8.586 5.5L8 6.086a1 1 0 0 0-.154.199 2 2 0 0 1 .861 3.337L6.88 11.45a2 2 0 1 1-2.83-2.83l.793-.792a4 4 0 0 1-.128-1.287z"/><path d="M6.586 4.672A3 3 0 0 0 7.414 9.5l.775-.776a2 2 0 0 1-.896-3.346L9.12 3.55a2 2 0 1 1 2.83 2.83l-.793.792c.112.42.155.855.128 1.287l1.372-1.372a3 3 0 1 0-4.243-4.243z"/>';
+                            const label = link.label || link.type || 'Link';
+                            linksHtml += `<a href="${escapeHtml(link.url)}" target="_blank" class="text-decoration-none" title="${escapeHtml(label)}"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="${color}" viewBox="0 0 16 16">${svgPaths}</svg></a>`;
+                        });
+                        linksHtml += '</div>';
+                    }
+
                     popup.setLngLat(info.coordinate)
                         .setHTML(`
                             <div class="route-popup">
                                 <strong>${transportIcons.plane} ${escapeHtml(d.tripTitle)}</strong>${appConfig?.tripPageEnabled ? ` <a href="trip.php?id=${d.tripId}" target="_blank" class="ms-1 text-muted text-decoration-none" title="${__('map.view_trip_details')}"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="currentColor" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M8.636 3.5a.5.5 0 0 0-.5-.5H1.5A1.5 1.5 0 0 0 0 4.5v10A1.5 1.5 0 0 0 1.5 16h10a1.5 1.5 0 0 0 1.5-1.5V7.864a.5.5 0 0 0-1 0V14.5a.5.5 0 0 1-.5.5h-10a.5.5 0 0 1-.5-.5v-10a.5.5 0 0 1 .5-.5h6.636a.5.5 0 0 0 .5-.5"/><path fill-rule="evenodd" d="M16 .5a.5.5 0 0 0-.5-.5h-5a.5.5 0 0 0 0 1h3.793L6.146 9.146a.5.5 0 1 0 .708.708L15 1.707V5.5a.5.5 0 0 0 1 0z"/></svg></a>` : ''}${futureLabel}
+                                ${d.routeName ? `<br><small class="text-primary fw-bold">${escapeHtml(d.routeName)}</small>` : ''}
+                                ${(d.startDatetime && d.startDatetime !== 'null') || (d.endDatetime && d.endDatetime !== 'null') ? `<br><small class="text-secondary">${formatRouteDatetime(d.startDatetime, d.endDatetime)}</small>` : ''}
+                                ${d.routeDescription ? `<br><small class="text-muted">${escapeHtml(d.routeDescription)}</small>` : ''}
+                                ${linksHtml}
                                 ${tagsHtml}
                                 <br>
                                 <small class="text-muted">${__('map.transport')}: ${__('map.transport_plane')}${formatDistance(d.distanceMeters, 'plane', d.isRoundTrip)}</small>

--- a/assets/js/public_map_leaflet.js
+++ b/assets/js/public_map_leaflet.js
@@ -346,6 +346,60 @@
     }
 
     /**
+     * Formatea fecha/hora de inicio y fin de ruta
+     */
+    function formatRouteDatetime(start, end) {
+        const isValid = (v) => v && v !== 'null' && v !== 'undefined' && v !== '';
+        if (!isValid(start) && !isValid(end)) return '';
+        
+        const opts = { day: '2-digit', month: 'short' };
+        const timeOpts = { hour: '2-digit', minute: '2-digit' };
+        const locale = document.documentElement.lang || 'es-ES';
+        
+        const parseDate = (dt) => {
+            if (!isValid(dt)) return null;
+            let d = new Date(dt);
+            if (!isNaN(d.getTime())) return d;
+            d = new Date(dt.replace(' ', 'T'));
+            if (!isNaN(d.getTime())) return d;
+            const parts = dt.match(/(\d{4})-(\d{2})-(\d{2})\s*(\d{2}):?(\d{2})?/);
+            if (parts) {
+                return new Date(parts[1], parts[2] - 1, parts[3], parts[4] || 0, parts[5] || 0);
+            }
+            return null;
+        };
+        
+        const formatDate = (dt) => {
+            const d = parseDate(dt);
+            if (!d) return '';
+            return d.toLocaleDateString(locale, opts);
+        };
+        
+        const formatTime = (dt) => {
+            const d = parseDate(dt);
+            if (!d) return '';
+            return d.toLocaleTimeString(locale, timeOpts);
+        };
+        
+        const startDate = formatDate(start);
+        const startTime = formatTime(start);
+        const endDate = formatDate(end);
+        const endTime = formatTime(end);
+        
+        if (startDate && startTime && endDate && endTime) {
+            return `${startDate} ${startTime} - ${endTime}`;
+        } else if (startDate && startTime) {
+            return `${startDate} ${startTime}`;
+        } else if (startDate) {
+            return startDate;
+        } else if (endDate && endTime) {
+            return `${endDate} ${endTime}`;
+        } else if (endDate) {
+            return endDate;
+        }
+        return '';
+
+    /**
      * Inicializa el mapa
      */
     function initMap() {
@@ -979,9 +1033,25 @@
                     tagsHtml += '</div>';
                 }
 
+                let linksHtml = '';
+                if (route.links && route.links.length > 0) {
+                    linksHtml = '<div class="mt-1 d-flex gap-1 flex-wrap">';
+                    route.links.forEach(link => {
+                        const color = link.color || '#6c757d';
+                        const svgPaths = link.svg_paths || '<path d="M4.715 6.542 3.343 7.914a3 3 0 1 0 4.243 4.243l1.828-1.829A3 3 0 0 0 8.586 5.5L8 6.086a1 1 0 0 0-.154.199 2 2 0 0 1 .861 3.337L6.88 11.45a2 2 0 1 1-2.83-2.83l.793-.792a4 4 0 0 1-.128-1.287z"/><path d="M6.586 4.672A3 3 0 0 0 7.414 9.5l.775-.776a2 2 0 0 1-.896-3.346L9.12 3.55a2 2 0 1 1 2.83 2.83l-.793.792c.112.42.155.855.128 1.287l1.372-1.372a3 3 0 1 0-4.243-4.243z"/>';
+                        const label = link.label || link.type || 'Link';
+                        linksHtml += `<a href="${escapeHtml(link.url)}" target="_blank" class="text-decoration-none" title="${escapeHtml(label)}"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="${color}" viewBox="0 0 16 16">${svgPaths}</svg></a>`;
+                    });
+                    linksHtml += '</div>';
+                }
+
                 lyr.bindPopup(`
                     <div class="route-popup">
                         <strong>${config.icon} ${escapeHtml(trip.title)}</strong>${appConfig?.tripPageEnabled ? ` <a href="trip.php?id=${trip.id}" target="_blank" class="ms-1 text-muted text-decoration-none" title="${__('map.view_trip_details')}"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="currentColor" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M8.636 3.5a.5.5 0 0 0-.5-.5H1.5A1.5 1.5 0 0 0 0 4.5v10A1.5 1.5 0 0 0 1.5 16h10a1.5 1.5 0 0 0 1.5-1.5V7.864a.5.5 0 0 0-1 0V14.5a.5.5 0 0 1-.5.5h-10a.5.5 0 0 1-.5-.5v-10a.5.5 0 0 1 .5-.5h6.636a.5.5 0 0 0 .5-.5"/><path fill-rule="evenodd" d="M16 .5a.5.5 0 0 0-.5-.5h-5a.5.5 0 0 0 0 1h3.793L6.146 9.146a.5.5 0 1 0 .708.708L15 1.707V5.5a.5.5 0 0 0 1 0z"/></svg></a>` : ''}${futureLabel}
+                        ${route.name ? `<br><small class="text-primary fw-bold">${escapeHtml(route.name)}</small>` : ''}
+                        ${(route.start_datetime && route.start_datetime !== 'null') || (route.end_datetime && route.end_datetime !== 'null') ? `<br><small class="text-secondary">${formatRouteDatetime(route.start_datetime, route.end_datetime)}</small>` : ''}
+                        ${route.description ? `<br><small class="text-muted">${escapeHtml(route.description)}</small>` : ''}
+                        ${linksHtml}
                         ${tagsHtml}
                         <br>
                         <small class="text-muted">${__('map.transport')}: ${__('map.transport_' + transportType)}${formatDistance(route.distance_meters, transportType, route.is_round_trip)}</small>
@@ -1194,9 +1264,25 @@
             tagsHtml += '</div>';
         }
 
+        let linksHtml = '';
+        if (route.links && route.links.length > 0) {
+            linksHtml = '<div class="mt-1 d-flex gap-1 flex-wrap">';
+            route.links.forEach(link => {
+                const color = link.color || '#6c757d';
+                const svgPaths = link.svg_paths || '<path d="M4.715 6.542 3.343 7.914a3 3 0 1 0 4.243 4.243l1.828-1.829A3 3 0 0 0 8.586 5.5L8 6.086a1 1 0 0 0-.154.199 2 2 0 0 1 .861 3.337L6.88 11.45a2 2 0 1 1-2.83-2.83l.793-.792a4 4 0 0 1-.128-1.287z"/><path d="M6.586 4.672A3 3 0 0 0 7.414 9.5l.775-.776a2 2 0 0 1-.896-3.346L9.12 3.55a2 2 0 1 1 2.83 2.83l-.793.792c.112.42.155.855.128 1.287l1.372-1.372a3 3 0 1 0-4.243-4.243z"/>';
+                const label = link.label || link.type || 'Link';
+                linksHtml += `<a href="${escapeHtml(link.url)}" target="_blank" class="text-decoration-none" title="${escapeHtml(label)}"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="${color}" viewBox="0 0 16 16">${svgPaths}</svg></a>`;
+            });
+            linksHtml += '</div>';
+        }
+
         layer.bindPopup(`
             <div class="route-popup">
                 <strong>${config.icon} ${escapeHtml(trip.title)}</strong>${appConfig?.tripPageEnabled ? ` <a href="trip.php?id=${trip.id}" target="_blank" class="ms-1 text-muted text-decoration-none" title="${__('map.view_trip_details')}"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="currentColor" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M8.636 3.5a.5.5 0 0 0-.5-.5H1.5A1.5 1.5 0 0 0 0 4.5v10A1.5 1.5 0 0 0 1.5 16h10a1.5 1.5 0 0 0 1.5-1.5V7.864a.5.5 0 0 0-1 0V14.5a.5.5 0 0 1-.5.5h-10a.5.5 0 0 1-.5-.5v-10a.5.5 0 0 1 .5-.5h6.636a.5.5 0 0 0 .5-.5"/><path fill-rule="evenodd" d="M16 .5a.5.5 0 0 0-.5-.5h-5a.5.5 0 0 0 0 1h3.793L6.146 9.146a.5.5 0 1 0 .708.708L15 1.707V5.5a.5.5 0 0 0 1 0z"/></svg></a>` : ''}${futureLabel}
+                ${route.name ? `<br><small class="text-primary fw-bold">${escapeHtml(route.name)}</small>` : ''}
+                ${(route.start_datetime && route.start_datetime !== 'null') || (route.end_datetime && route.end_datetime !== 'null') ? `<br><small class="text-secondary">${formatRouteDatetime(route.start_datetime, route.end_datetime)}</small>` : ''}
+                ${route.description ? `<br><small class="text-muted">${escapeHtml(route.description)}</small>` : ''}
+                ${linksHtml}
                 ${tagsHtml}
                 <br>
                 <small class="text-muted">${__('map.transport_plane')}${formatDistance(route.distance_meters, 'plane', route.is_round_trip)}</small>

--- a/assets/js/trip_map.js
+++ b/assets/js/trip_map.js
@@ -147,12 +147,13 @@
                 <table class="table table-sm table-hover mb-0">
                     <thead>
                         <tr>
-                            <th style="width: 50px; text-align: center;">#</th>
-                            <th style="width: 60px; text-align: center;"></th>
-                            <th>${__('routes.transport_type') || 'Transport Type'}</th>
-                            <th style="width: 80px; text-align: center;">${__('routes.is_round_trip') || 'Round Trip'}</th>
-                            <th style="width: 100px; text-align: center;">${__('routes.distance') || 'Distance'}</th>
-                            <th style="width: 100px; text-align: center;">${__('trips.actions') || 'Actions'}</th>
+                            <th style="width: 40px; text-align: center;">#</th>
+                            <th style="width: 50px; text-align: center;"></th>
+                            <th>${__('routes.route_name') || 'Nombre'}</th>
+                            <th style="width: 60px; text-align: center;">${__('routes.transport_type') || 'Tipo'}</th>
+                            <th style="width: 70px; text-align: center;">${__('routes.is_round_trip') || 'Ida/Vuelta'}</th>
+                            <th style="width: 90px; text-align: center;">${__('routes.distance') || 'Distancia'}</th>
+                            <th style="width: 80px; text-align: center;">${__('trips.actions') || 'Acciones'}</th>
                         </tr>
                     </thead>
                     <tbody id="routesTableBody"></tbody>
@@ -166,6 +167,8 @@
         routesData.forEach(function (route, index) {
             const color = route.color || transportColors[route.transport_type];
             const icon = transportIcons[route.transport_type] || '';
+            const routeName = route.name || '<em class="text-muted">—</em>';
+            const hasDetails = route.name || route.description;
 
             // Build transport type selector
             const transportOrder = ['plane', 'car', 'bike', 'train', 'ship', 'walk', 'bus', 'aerial'];
@@ -179,9 +182,13 @@
             const row = $(`
                 <tr data-route-index="${index}" style="cursor: pointer;" title="${__('map.focus_route')}">
                     <td class="text-center align-middle">
-                        <div style="width: 30px; height: 4px; background-color: ${color}; margin: 0 auto;"></div>
+                        <div style="width: 20px; height: 4px; background-color: ${color}; margin: 0 auto;"></div>
                     </td>
                     <td class="text-center align-middle">${icon}</td>
+                    <td class="align-middle small">
+                        <span class="route-name-cell">${routeName}</span>
+                        ${hasDetails ? '<i class="bi bi-pencil text-primary ms-1" style="font-size: 10px;"></i>' : ''}
+                    </td>
                     <td class="align-middle">
                         <select class="form-select form-select-sm transport-type-selector" data-route-index="${index}">
                             ${optionsHtml}
@@ -196,8 +203,13 @@
                         ${formatDistanceDisplay(route.distance_meters, route.transport_type, route.is_round_trip)}
                     </td>
                     <td class="text-center align-middle">
+                        <button class="btn btn-sm btn-outline-primary edit-route-btn" data-route-index="${index}" title="${__('routes.edit_route') || 'Editar'}">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="currentColor" viewBox="0 0 16 16">
+                                <path d="M12.146.146a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1 0 .708l-10 10a.5.5 0 0 1-.168.11l-5 2a.5.5 0 0 1-.65-.65l2-5a.5.5 0 0 1 .11-.168zM11.207 2.5 13.5 4.793 14.793 3.5 12.5 1.207zm1.586 3L10.5 3.207 4 9.707V10h.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.5h.293zm-9.761 5.175-.106.106-1.528 3.821 3.821-1.528.106-.106A.5.5 0 0 1 5 12.5V12h-.5a.5.5 0 0 1-.5-.5V11h-.5a.5.5 0 0 1-.468-.325"/>
+                            </svg>
+                        </button>
                         <button class="btn btn-sm btn-outline-danger delete-route-btn" data-route-index="${index}" title="${__('map.delete_route')}">
-                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="currentColor" class="bi bi-trash" viewBox="0 0 16 16">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="currentColor" viewBox="0 0 16 16">
                                 <path d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0z"/>
                                 <path d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1zM4.118 4 4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4zM2.5 3h11V2h-11z"/>
                             </svg>
@@ -409,6 +421,9 @@
         // Cargar rutas existentes
         loadExistingRoutes();
 
+        // Inicializar modal de edición de ruta
+        initRouteModal();
+
         // Cargar puntos existentes
         loadExistingPoints();
 
@@ -565,10 +580,15 @@
             routesData.push({
                 transport_type: layer.transportType || 'car',
                 color: layer.color || transportColors['car'],
-                is_round_trip: layer.isRoundTrip === true, // Asegurar que sea explícitamente true
+                is_round_trip: layer.isRoundTrip === true,
                 distance_meters: distanceForInfo,
                 geojson: geojson,
-                layer: layer  // Keep reference to the layer
+                name: layer.routeName || '',
+                description: layer.routeDescription || '',
+                start_datetime: layer.startDatetime || '',
+                end_datetime: layer.endDatetime || '',
+                links: layer.routeLinks || [],
+                layer: layer
             });
         });
 
@@ -577,7 +597,12 @@
             transport_type: route.transport_type,
             color: route.color,
             is_round_trip: route.is_round_trip ? 1 : 0,
-            geojson: route.geojson
+            geojson: route.geojson,
+            name: route.name,
+            description: route.description,
+            start_datetime: route.start_datetime,
+            end_datetime: route.end_datetime,
+            links: route.links || []
         }));
         document.getElementById('routes_data').value = JSON.stringify(routesDataForSave);
 
@@ -615,9 +640,13 @@
             layer.eachLayer(function (l) {
                 l.transportType = transportType;
                 l.color = color;
-                // Asegurar que is_round_trip sea boolean y solo true si es 1 o true
                 l.isRoundTrip = route.is_round_trip === 1 || route.is_round_trip === true || route.is_round_trip === "1";
                 l.distanceMeters = route.distance_meters;
+                l.routeName = route.name || '';
+                l.routeDescription = route.description || '';
+                l.startDatetime = route.start_datetime || '';
+                l.endDatetime = route.end_datetime || '';
+                l.routeLinks = route.links || [];
                 drawnItems.addLayer(l);
             });
         });
@@ -919,6 +948,165 @@
         });
 
         console.log('Trip Map Editor inicializado');
+    }
+
+    /**
+     * Inicializa el modal para editar nombre y descripción de rutas
+     */
+    function initRouteModal() {
+        // Crear modal HTML si no existe
+        if ($('#routeEditModal').length === 0) {
+            const linkTypes = Object.keys(window.routeLinkTypes || {
+                'website': 'Website',
+                'google_maps': 'Google Maps',
+                'other': 'Enlace'
+            });
+            let linkOptionsHtml = '';
+            linkTypes.forEach(type => {
+                const label = window.routeLinkTypes?.[type]?.label || type;
+                linkOptionsHtml += `<option value="${type}">${label}</option>`;
+            });
+            
+            const modalHtml = `
+            <div class="modal fade" id="routeEditModal" tabindex="-1" aria-hidden="true">
+                <div class="modal-dialog">
+                    <div class="modal-content">
+                        <div class="modal-header">
+                            <h5 class="modal-title">${__('routes.edit_route') || 'Editar Ruta'}</h5>
+                            <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                        </div>
+                        <div class="modal-body">
+                            <div class="row">
+                                <div class="col-md-6 mb-3">
+                                    <label class="form-label">${__('routes.start_datetime') || 'Inicio'}</label>
+                                    <input type="datetime-local" class="form-control" id="routeStartDatetimeInput">
+                                </div>
+                                <div class="col-md-6 mb-3">
+                                    <label class="form-label">${__('routes.end_datetime') || 'Fin'}</label>
+                                    <input type="datetime-local" class="form-control" id="routeEndDatetimeInput">
+                                </div>
+                            </div>
+                            <div class="mb-3">
+                                <label class="form-label">${__('routes.route_name') || 'Nombre'}</label>
+                                <input type="text" class="form-control" id="routeNameInput" placeholder="${__('routes.name_placeholder') || 'Ej: Vuelo EZE-MAD'}">
+                            </div>
+                            <div class="mb-3">
+                                <label class="form-label">${__('routes.description') || 'Descripción'}</label>
+                                <textarea class="form-control" id="routeDescInput" rows="3" placeholder="${__('routes.description_placeholder') || 'Notas sobre esta ruta...'}"></textarea>
+                            </div>
+                            <div class="mb-3">
+                                <label class="form-label">${__('routes.external_links') || 'Links Externos'}</label>
+                                <div id="route-links-container"></div>
+                                <button type="button" class="btn btn-outline-secondary btn-sm mt-2" id="addRouteLinkBtn">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="currentColor" viewBox="0 0 16 16"><path d="M8.186 1.113a.5.5 0 0 0-.372 0L1.846 3.5l2.404.961L10.404 2l-2.218-.887zm3.564 1.426L5.596 5 8 5.961l1.598-1.5zM7.5 14H5.092l1.406-1.406 2.002 2.002 2.002-2.002.998.998-.5.5a2.5 2.5 0 0 1-3.5 3.5l-.5-.5.998-.998 1.5 1.5 1.5-1.5-.998-.998.5-.5a2.5 2.5 0 0 1 3.5-3.5l.5.5-1.5 1.5-.998.998.5.5a2.5 2.5 0 0 1-3.5 3.5l-.5-.5-2.002 2.002z"/></svg>
+                                    ${__('routes.add_link') || 'Agregar link'}
+                                </button>
+                                <template id="route-link-template">
+                                    <div class="route-link-row input-group mb-2">
+                                        <select class="form-select" style="max-width: 180px;">
+                                            ${linkOptionsHtml}
+                                        </select>
+                                        <input type="url" class="form-control" placeholder="https://" required>
+                                        <input type="text" class="form-control" placeholder="${__('routes.link_label_optional') || 'Etiqueta (opcional)'}" style="max-width: 140px;">
+                                        <button type="button" class="btn btn-outline-danger remove-link-btn">
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="currentColor" viewBox="0 0 16 16"><path d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0z"/><path d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1zM4.118 4 4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4zM2.5 3h11V2h-11z"/></svg>
+                                        </button>
+                                    </div>
+                                </template>
+                            </div>
+                        </div>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">${__('common.cancel') || 'Cancelar'}</button>
+                            <button type="button" class="btn btn-primary" id="saveRouteDetails">${__('common.save') || 'Guardar'}</button>
+                        </div>
+                    </div>
+                </div>
+            </div>`;
+            $('body').append(modalHtml);
+            
+            // Event handlers para links
+            $(document).on('click', '#addRouteLinkBtn', function() {
+                const template = $('#route-link-template').html();
+                $('#route-links-container').append(template);
+            });
+            
+            $(document).on('click', '.remove-link-btn', function() {
+                $(this).closest('.route-link-row').remove();
+            });
+        }
+
+        let currentRouteIndex = null;
+
+        // Botón de editar en cada fila
+        $(document).on('click', '.edit-route-btn', function() {
+            const index = parseInt($(this).data('route-index'));
+            currentRouteIndex = index;
+            const route = routesData[index];
+            
+            // Formatear datetime para input datetime-local (YYYY-MM-DDTHH:MM)
+            const formatDatetimeLocal = (dt) => {
+                if (!dt) return '';
+                const d = new Date(dt);
+                return d.toISOString().slice(0, 16);
+            };
+            
+            $('#routeStartDatetimeInput').val(formatDatetimeLocal(route.start_datetime));
+            $('#routeEndDatetimeInput').val(formatDatetimeLocal(route.end_datetime));
+            $('#routeNameInput').val(route.name || '');
+            $('#routeDescInput').val(route.description || '');
+            
+            // Cargar links
+            $('#route-links-container').empty();
+            if (route.links && route.links.length > 0) {
+                route.links.forEach(link => {
+                    const template = $('#route-link-template').html();
+                    const row = $(template);
+                    row.find('select').val(link.type || 'website');
+                    row.find('input[type="url"]').val(link.url || '');
+                    row.find('input[type="text"]').val(link.label || '');
+                    $('#route-links-container').append(row);
+                });
+            }
+            
+            const modal = new bootstrap.Modal($('#routeEditModal'));
+            modal.show();
+        });
+
+        // Guardar cambios
+        $('#saveRouteDetails').on('click', function() {
+            if (currentRouteIndex !== null && routesData[currentRouteIndex]) {
+                const route = routesData[currentRouteIndex];
+                route.start_datetime = $('#routeStartDatetimeInput').val() || null;
+                route.end_datetime = $('#routeEndDatetimeInput').val() || null;
+                route.name = $('#routeNameInput').val();
+                route.description = $('#routeDescInput').val();
+                
+                // Recolectar links
+                route.links = [];
+                $('#route-links-container .route-link-row').each(function() {
+                    const linkType = $(this).find('select').val();
+                    const linkUrl = $(this).find('input[type="url"]').val();
+                    const linkLabel = $(this).find('input[type="text"]').val();
+                    if (linkUrl) {
+                        route.links.push({
+                            link_type: linkType,
+                            url: linkUrl,
+                            label: linkLabel || ''
+                        });
+                    }
+                });
+                
+                if (route.layer) {
+                    route.layer.routeName = route.name;
+                    route.layer.routeDescription = route.description;
+                    route.layer.startDatetime = route.start_datetime;
+                    route.layer.endDatetime = route.end_datetime;
+                    route.layer.routeLinks = route.links;
+                }
+                updateRoutesData();
+                bootstrap.Modal.getInstance($('#routeEditModal')).hide();
+            }
+        });
     }
 
 })();

--- a/assets/js/trip_single.js
+++ b/assets/js/trip_single.js
@@ -500,7 +500,23 @@ function initInteractions() {
             const lat = parseFloat(el.dataset.lat);
             const lng = parseFloat(el.dataset.lng);
             const id = el.dataset.id;
+            const routeId = el.dataset.routeId;
 
+            // Handle route click
+            if (routeId) {
+                const route = TRIP_DATA.routes.find(r => String(r.id) === String(routeId));
+                if (route && route.geojson) {
+                    // Highlight active item in timeline
+                    document.querySelectorAll('.timeline-point').forEach(p => p.classList.remove('active'));
+                    el.classList.add('active');
+
+                    // Fit map bounds to route
+                    fitToRoute(route);
+                }
+                return;
+            }
+
+            // Handle point click (original behavior)
             if (isNaN(lat) || isNaN(lng)) return;
 
             // Highlight active point in timeline
@@ -534,6 +550,24 @@ function initInteractions() {
             }
         });
     });
+}
+
+function fitToRoute(route) {
+    if (!route.geojson || !route.geojson.geometry || !route.geojson.geometry.coordinates) return;
+
+    const coords = route.geojson.geometry.coordinates;
+    if (coords.length === 0) return;
+
+    if (MAP_RENDERER === 'leaflet') {
+        const latLngs = coords.map(c => L.latLng(c[1], c[0]));
+        const bounds = L.latLngBounds(latLngs);
+        map.fitBounds(bounds, { padding: [50, 50], maxZoom: 12 });
+    } else {
+        const maplibregl = window.maplibregl;
+        if (!maplibregl) return;
+        const bounds = coords.reduce((b, c) => b.extend(c), new maplibregl.LngLatBounds(coords[0], coords[0]));
+        map.fitBounds(bounds, { padding: 50, maxZoom: 12 });
+    }
 }
 
 // openLightbox alias — called from map-renderer popup image onclick

--- a/database.sql
+++ b/database.sql
@@ -53,6 +53,9 @@ CREATE TABLE IF NOT EXISTS routes (
     is_round_trip TINYINT(1) DEFAULT 1,
     distance_meters INT UNSIGNED DEFAULT 0,
     color VARCHAR(7) DEFAULT '#3388ff',
+    name VARCHAR(200) DEFAULT NULL,
+    description TEXT DEFAULT NULL,
+    image_path VARCHAR(255) DEFAULT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     FOREIGN KEY (trip_id) REFERENCES trips(id) ON DELETE CASCADE,
@@ -196,6 +199,26 @@ CREATE TABLE IF NOT EXISTS poi_links (
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (poi_id) REFERENCES points_of_interest(id) ON DELETE CASCADE,
     INDEX idx_poi_id (poi_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- ============================================
+-- Tabla: route_links
+-- Descripción: Links externos tipificados para trayectos
+-- ============================================
+CREATE TABLE IF NOT EXISTS route_links (
+    id         INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    route_id   INT UNSIGNED NOT NULL,
+    link_type  ENUM(
+                   'website', 'google_maps', 'instagram', 'facebook',
+                   'twitter', 'tripadvisor', 'booking', 'airbnb',
+                   'youtube', 'wikipedia', 'google_photos', 'other'
+               ) NOT NULL DEFAULT 'website',
+    url        VARCHAR(500) NOT NULL,
+    label      VARCHAR(100) DEFAULT NULL,
+    sort_order TINYINT UNSIGNED DEFAULT 0,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (route_id) REFERENCES routes(id) ON DELETE CASCADE,
+    INDEX idx_route_id (route_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- ============================================

--- a/install/migrations/017_route_metadata.php
+++ b/install/migrations/017_route_metadata.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Migration 017: Route Metadata
+ *
+ * Agrega columnas de metadatos a la tabla routes:
+ * - name:        nombre descriptivo opcional del trayecto
+ * - description: texto libre (equivalente al description de points_of_interest)
+ * - image_path:  ruta relativa de la imagen subida al servidor
+ *                (mismo esquema que points_of_interest.image_path)
+ */
+class Migration_017_route_metadata
+{
+    public static function id(): string
+    {
+        return '017_route_metadata';
+    }
+
+    public static function description(): string
+    {
+        return 'Agregar name, description e image_path a la tabla routes';
+    }
+
+    public static function check(PDO $db): bool
+    {
+        $stmt = $db->query("SHOW COLUMNS FROM routes LIKE 'name'");
+        return (bool) $stmt->fetchColumn();
+    }
+
+    public static function up(PDO $db): void
+    {
+        $db->exec("
+            ALTER TABLE routes
+                ADD COLUMN name        VARCHAR(200) DEFAULT NULL AFTER color,
+                ADD COLUMN description TEXT         DEFAULT NULL AFTER name,
+                ADD COLUMN image_path  VARCHAR(255) DEFAULT NULL AFTER description
+        ");
+    }
+}

--- a/install/migrations/018_route_links_table.php
+++ b/install/migrations/018_route_links_table.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Migration 018: Route Links Table
+ *
+ * Crea la tabla route_links para enlaces externos tipificados
+ * asociados a trayectos (routes). Es la contraparte exacta de
+ * poi_links para puntos de interés: mismos tipos de enlace,
+ * misma estructura, FK apuntando a routes(id).
+ */
+class Migration_018_route_links_table
+{
+    public static function id(): string
+    {
+        return '018_route_links_table';
+    }
+
+    public static function description(): string
+    {
+        return 'Tabla route_links: enlaces externos para trayectos';
+    }
+
+    public static function check(PDO $db): bool
+    {
+        $stmt = $db->query("SHOW TABLES LIKE 'route_links'");
+        return (bool) $stmt->fetchColumn();
+    }
+
+    public static function up(PDO $db): void
+    {
+        $db->exec("
+            CREATE TABLE IF NOT EXISTS route_links (
+                id         INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                route_id   INT UNSIGNED NOT NULL,
+                link_type  ENUM(
+                               'website', 'google_maps', 'instagram', 'facebook',
+                               'twitter', 'tripadvisor', 'booking', 'airbnb',
+                               'youtube', 'wikipedia', 'google_photos', 'other'
+                           ) NOT NULL DEFAULT 'website',
+                url        VARCHAR(500) NOT NULL,
+                label      VARCHAR(100) DEFAULT NULL,
+                sort_order TINYINT UNSIGNED DEFAULT 0,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (route_id) REFERENCES routes(id) ON DELETE CASCADE,
+                INDEX idx_route_id (route_id)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+        ");
+    }
+}

--- a/install/migrations/019_route_datetime.php
+++ b/install/migrations/019_route_datetime.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Migration 019: Route Datetime
+ *
+ * Agrega campos de fecha y hora a la tabla routes:
+ * - start_datetime: fecha y hora de inicio del trayecto
+ * - end_datetime:   fecha y hora de fin del trayecto
+ *                 (mismo esquema que points_of_interest.visit_date)
+ */
+class Migration_019_route_datetime
+{
+    public static function id(): string
+    {
+        return '019_route_datetime';
+    }
+
+    public static function description(): string
+    {
+        return 'Agregar start_datetime y end_datetime a la tabla routes';
+    }
+
+    public static function check(PDO $db): bool
+    {
+        $stmt = $db->query("SHOW COLUMNS FROM routes LIKE 'start_datetime'");
+        return (bool) $stmt->fetchColumn();
+    }
+
+    public static function up(PDO $db): void
+    {
+        $db->exec("
+            ALTER TABLE routes
+                ADD COLUMN start_datetime DATETIME DEFAULT NULL AFTER image_path,
+                ADD COLUMN end_datetime   DATETIME DEFAULT NULL AFTER start_datetime
+        ");
+    }
+}

--- a/lang/en.json
+++ b/lang/en.json
@@ -356,6 +356,7 @@
   },
   "routes": {
     "title": "Routes",
+    "route": "Route",
     "transport_type": "Transport Type",
     "transport_types": {
       "plane": "Plane",
@@ -373,7 +374,17 @@
     "error_saving": "Error processing route data",
     "detected_distance": "Detected distance",
     "enter_transport_number": "Enter the number",
-    "invalid_option_default": "Invalid option. Selecting Car by default."
+    "invalid_option_default": "Invalid option. Selecting Car by default.",
+    "edit_route": "Edit Route",
+    "route_name": "Name",
+    "name_placeholder": "Eg: Flight EZE-MAD",
+    "description": "Description",
+    "description_placeholder": "Notes about this route...",
+    "start_datetime": "Start",
+    "end_datetime": "End",
+    "external_links": "External Links",
+    "add_link": "Add link",
+    "link_label_optional": "Label (optional)"
   },
   "users": {
     "title": "Users",

--- a/lang/es.json
+++ b/lang/es.json
@@ -355,6 +355,7 @@
   },
   "routes": {
     "title": "Rutas",
+    "route": "Ruta",
     "transport_type": "Tipo de Transporte",
     "transport_types": {
       "plane": "Avión",
@@ -372,7 +373,17 @@
     "error_saving": "Error al procesar los datos de las rutas",
     "detected_distance": "Distancia detectada",
     "enter_transport_number": "Ingresa el número",
-    "invalid_option_default": "Opción no válida. Seleccionando Auto por defecto."
+    "invalid_option_default": "Opción no válida. Seleccionando Auto por defecto.",
+    "edit_route": "Editar Ruta",
+    "route_name": "Nombre",
+    "name_placeholder": "Ej: Vuelo EZE-MAD",
+    "description": "Descripción",
+    "description_placeholder": "Notas sobre esta ruta...",
+    "start_datetime": "Inicio",
+    "end_datetime": "Fin",
+    "external_links": "Links Externos",
+    "add_link": "Agregar link",
+    "link_label_optional": "Etiqueta (opcional)"
   },
   "users": {
     "title": "Usuarios",

--- a/src/helpers/DateTimeHelper.php
+++ b/src/helpers/DateTimeHelper.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Helper: DateTime utilities
+ */
+
+if (!function_exists('formatRouteDatetime')) {
+    /**
+     * Formatea fecha/hora de inicio y fin de ruta
+     * 
+     * @param string|null $start Fecha/hora de inicio en formato MySQL (YYYY-MM-DD HH:MM:SS)
+     * @param string|null $end   Fecha/hora de fin en formato MySQL (YYYY-MM-DD HH:MM:SS)
+     * @return string             Fecha formateada o string vacío
+     */
+    function formatRouteDatetime(?string $start, ?string $end = null): string {
+        $isValid = fn($v) => $v && $v !== 'null' && $v !== 'undefined' && $v !== '';
+        
+        if (!$isValid($start) && !$isValid($end)) {
+            return '';
+        }
+        
+        $locale = function_exists('current_lang') ? current_lang() : 'es';
+        $dateLocale = $locale === 'en' ? 'en-GB' : 'es-ES';
+        
+        $formatDate = function($dt) use ($dateLocale) {
+            if (!$dt) return '';
+            $d = DateTime::createFromFormat('Y-m-d H:i:s', $dt);
+            if (!$d) {
+                $d = DateTime::createFromFormat('Y-m-d H:i', $dt);
+            }
+            if (!$d) {
+                $d = DateTime::createFromFormat('Y-m-d', $dt);
+            }
+            if ($d) {
+                return $d->format('d M');
+            }
+            return '';
+        };
+        
+        $formatTime = function($dt) use ($dateLocale) {
+            if (!$dt) return '';
+            $d = DateTime::createFromFormat('Y-m-d H:i:s', $dt);
+            if (!$d) {
+                $d = DateTime::createFromFormat('Y-m-d H:i', $dt);
+            }
+            if ($d) {
+                return $d->format('H:i');
+            }
+            return '';
+        };
+        
+        $startDate = $formatDate($start);
+        $startTime = $formatTime($start);
+        $endDate = $formatDate($end);
+        $endTime = $formatTime($end);
+        
+        if ($startDate && $startTime && $endDate && $endTime) {
+            return sprintf('%s %s - %s', $startDate, $startTime, $endTime);
+        } else if ($startDate && $startTime) {
+            return sprintf('%s %s', $startDate, $startTime);
+        } else if ($startDate) {
+            return $startDate;
+        } else if ($startTime) {
+            return $startTime;
+        } else if ($endDate && $endTime) {
+            return sprintf('%s %s', $endDate, $endTime);
+        } else if ($endDate) {
+            return $endDate;
+        } else if ($endTime) {
+            return $endTime;
+        }
+        
+        return '';
+    }
+}

--- a/src/models/Route.php
+++ b/src/models/Route.php
@@ -67,17 +67,22 @@ class Route {
             }
 
             $stmt = $this->db->prepare('
-                INSERT INTO routes (trip_id, transport_type, geojson_data, is_round_trip, distance_meters, color)
-                VALUES (?, ?, ?, ?, ?, ?)
+                INSERT INTO routes (trip_id, transport_type, geojson_data, is_round_trip, distance_meters, color, name, description, image_path, start_datetime, end_datetime)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ');
             
             $result = $stmt->execute([
                 $data['trip_id'],
                 $data['transport_type'],
                 $data['geojson_data'],
-                $data['is_round_trip'] ?? 1,
+                $data['is_round_trip'] ?? 0,
                 $distance,
-                $data['color'] ?? '#3388ff'
+                $data['color'] ?? '#3388ff',
+                $data['name'] ?? null,
+                $data['description'] ?? null,
+                $data['image_path'] ?? null,
+                $data['start_datetime'] ?? null,
+                $data['end_datetime'] ?? null
             ]);
 
             return $result ? $this->db->lastInsertId() : false;
@@ -106,7 +111,7 @@ class Route {
 
             $stmt = $this->db->prepare('
                 UPDATE routes 
-                SET transport_type = ?, geojson_data = ?, is_round_trip = ?, distance_meters = ?, color = ?
+                SET transport_type = ?, geojson_data = ?, is_round_trip = ?, distance_meters = ?, color = ?, name = ?, description = ?, image_path = ?, start_datetime = ?, end_datetime = ?
                 WHERE id = ?
             ');
             
@@ -116,6 +121,11 @@ class Route {
                 $data['is_round_trip'] ?? 0,
                 $distance,
                 $data['color'] ?? '#3388ff',
+                $data['name'] ?? null,
+                $data['description'] ?? null,
+                $data['image_path'] ?? null,
+                $data['start_datetime'] ?? null,
+                $data['end_datetime'] ?? null,
                 $id
             ]);
         } catch (PDOException $e) {

--- a/src/models/RouteLink.php
+++ b/src/models/RouteLink.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Modelo: RouteLink
+ *
+ * Gestiona los links externos asociados a rutas/trayectos
+ */
+
+class RouteLink {
+    private $db;
+
+    const TYPES = [
+        'website'       => ['label' => 'Website',        'color' => '#0d6efd', 'svg_paths' => '<path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8m7.5-6.923c-.67.204-1.335.82-1.887 1.855A8 8 0 0 0 5.145 4H7.5zM4.09 4a9.3 9.3 0 0 1 .64-1.539 7 7 0 0 1 .597-.933A7.03 7.03 0 0 0 2.255 4zm-.582 3.5c.03-.877.138-1.718.312-2.5H1.674a7 7 0 0 0-.656 2.5zM4.847 5a12.5 12.5 0 0 0-.338 2.5H7.5V5zM8.5 5v2.5h2.99a12.5 12.5 0 0 0-.337-2.5zM4.51 8.5a12.5 12.5 0 0 0 .337 2.5H7.5V8.5zm3.99 0V11h2.653c.187-.765.306-1.608.338-2.5zM5.145 12q.208.58.468 1.068c.552 1.035 1.218 1.65 1.887 1.855V12zm.182 2.472a7 7 0 0 1-.597-.933A9.3 9.3 0 0 1 4.09 12H2.255a7 7 0 0 0 3.072 2.472M3.82 11a13.7 13.7 0 0 1-.312-2.5h-2.49c.062.89.291 1.733.656 2.5zm6.853 3.472A7 7 0 0 0 13.745 12H11.91a9.3 9.3 0 0 1-.64 1.539 7 7 0 0 1-.597.933M8.5 12v2.923c.67-.204 1.335-.82 1.887-1.855q.26-.487.468-1.068zm3.68-1h2.146c.365-.767.594-1.61.656-2.5h-2.49a13.7 13.7 0 0 1-.312 2.5m2.802-3.5a7 7 0 0 0-.656-2.5H12.18c.174.782.282 1.623.312 2.5zM11.27 2.461c.247.464.462.98.64 1.539h1.835a7 7 0 0 0-3.072-2.472c.218.284.418.598.597.933M10.855 4a8 8 0 0 0-.468-1.068C9.835 1.897 9.17 1.282 8.5 1.077V4z"/>'],
+        'google_maps'  => ['label' => 'Google Maps',   'color' => '#ea4335', 'svg_paths' => '<path d="M8 16s6-5.686 6-10A6 6 0 0 0 2 6c0 4.314 6 10 6 10m0-7a3 3 0 1 1 0-6 3 3 0 0 1 0 6"/>'],
+        'instagram'    => ['label' => 'Instagram',     'color' => '#c13584', 'svg_paths' => '<path d="M8 0C5.829 0 5.556.01 4.703.048 3.85.088 3.269.222 2.76.42a3.9 3.9 0 0 0-1.417.923A3.9 3.9 0 0 0 .42 2.76C.222 3.268.087 3.85.048 4.7.01 5.555 0 5.827 0 8.001c0 2.172.01 2.444.048 3.297.04.852.174 1.433.372 1.942.205.526.478.972.923 1.417.444.445.89.719 1.416.923.51.198 1.09.333 1.942.372C5.555 15.99 5.827 16 8 16s2.444-.01 3.298-.048c.851-.04 1.434-.174 1.943-.372a3.9 3.9 0 0 0 1.416-.923c.445-.445.718-.891.923-1.417.197-.509.332-1.09.372-1.942C15.99 10.445 16 10.173 16 8s-.01-2.445-.048-3.299c-.04-.851-.175-1.433-.372-1.941a3.9 3.9 0 0 0-.923-1.417A3.9 3.9 0 0 0 13.24.42c-.51-.198-1.092-.333-1.943-.372C10.443.01 10.172 0 7.998 0zm-.717 1.442h.718c2.136 0 2.389.007 3.232.046.78.035 1.204.166 1.486.275.373.145.64.319.92.599s.453.546.598.92c.11.281.24.705.275 1.485.039.843.047 1.096.047 3.231s-.008 2.389-.047 3.232c-.035.78-.166 1.203-.275 1.485a2.5 2.5 0 0 1-.599.919c-.28.28-.546.453-.92.598-.28.11-.704.24-1.485.276-.843.038-1.096.047-3.232.047s-2.39-.009-3.233-.047c-.78-.036-1.203-.166-1.485-.276a2.5 2.5 0 0 1-.92-.598 2.5 2.5 0 0 1-.6-.92c-.109-.281-.24-.705-.275-1.485-.038-.843-.046-1.096-.046-3.233s.008-2.388.046-3.231c.036-.78.166-1.204.276-1.486.145-.373.319-.64.599-.92s.546-.453.92-.598c.282-.11.705-.24 1.485-.276.738-.034 1.024-.044 2.515-.045zm4.988 1.328a.96.96 0 1 0 0 1.92.96.96 0 0 0 0-1.92m-4.27 1.122a4.109 4.109 0 1 0 0 8.217 4.109 4.109 0 0 0 0-8.217m0 1.441a2.667 2.667 0 1 1 0 5.334 2.667 2.667 0 0 1 0-5.334"/>'],
+        'facebook'     => ['label' => 'Facebook',      'color' => '#1877f2', 'svg_paths' => '<path d="M16 8.049c0-4.446-3.582-8.05-8-8.05C3.58 0-.002 3.603-.002 8.05c0 4.017 2.926 7.347 6.75 7.951v-5.625h-2.03V8.05H6.75V6.275c0-2.017 1.195-3.131 3.022-3.131.876 0 1.791.157 1.791.157v1.98h-1.009c-.993 0-1.303.621-1.303 1.258v1.51h2.218l-.354 2.326H9.25V16c3.824-.604 6.75-3.934 6.75-7.951"/>'],
+        'twitter'      => ['label' => 'Twitter / X',   'color' => '#000000', 'svg_paths' => '<path d="M12.6.75h2.454l-5.36 6.142L16 15.25h-4.937l-3.867-5.07-4.425 5.07H.316l5.733-6.57L0 .75h5.063l3.495 4.633L12.601.75Zm-.86 13.028h1.36L4.323 2.145H2.865z"/>'],
+        'tripadvisor'  => ['label' => 'TripAdvisor',   'color' => '#34e0a1', 'svg_paths' => '<path d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3"/><path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8m8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13"/>'],
+        'booking'      => ['label' => 'Booking.com',   'color' => '#003580', 'svg_paths' => '<path d="M2 2a2 2 0 0 0-2 2v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2zm1 2h10a1 1 0 0 1 1 1v6a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1"/>'],
+        'airbnb'       => ['label' => 'Airbnb',        'color' => '#ff5a5f', 'svg_paths' => '<path d="M8 0C3.584 0 0 3.584 0 8s3.584 8 8 8 8-3.584 8-8-3.584-8-8-8m0 4a4 4 0 1 1 0 8 4 4 0 0 1 0-8m0 1.5a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5"/>'],
+        'youtube'      => ['label' => 'YouTube',       'color' => '#ff0000', 'svg_paths' => '<path d="M8.051 1.999h.089c.822.003 4.987.033 6.11.335a2.01 2.01 0 0 1 1.415 1.42c.101.38.172.883.22 1.402l.01.104.022.26.008.104c.065.914.073 1.77.074 1.957v.075c-.001.194-.01 1.108-.082 2.06l-.008.105-.009.104c-.05.572-.124 1.14-.235 1.558a2.01 2.01 0 0 1-1.415 1.42c-1.16.312-5.569.334-6.18.335h-.142c-.309 0-1.587-.006-2.927-.052l-.17-.006-.087-.004-.171-.007-.171-.007c-1.11-.049-2.167-.128-2.654-.26a2.01 2.01 0 0 1-1.415-1.419c-.111-.417-.185-.986-.235-1.558L.09 9.82l-.008-.104A31 31 0 0 1 0 7.68v-.123c.002-.215.01-.958.064-1.778l.007-.103.003-.052.008-.104.022-.26.01-.104c.048-.519.119-1.023.22-1.402a2.01 2.01 0 0 1 1.415-1.42c.487-.13 1.544-.21 2.654-.26l.17-.007.172-.006.086-.003.171-.007A100 100 0 0 1 7.858 2zM6.4 5.209v4.818l4.157-2.408z"/>'],
+        'wikipedia'    => ['label' => 'Wikipedia',     'color' => '#000000', 'svg_paths' => '<path d="M1 2.5h2l2.5 9 2-6 2 6 2.5-9H14l-3.25 11H9L8 10l-1 3.5H5.25z"/>'],
+        'google_photos'=> ['label' => 'Google Photos', 'color' => '#4285f4', 'svg_paths' => '<g transform="scale(0.271)"><path fill="#FBBC04" d="M14.75 13.41c8.146 0 14.75 6.603 14.75 14.75v1.34H1.34C.6 29.5 0 28.9 0 28.16c0-8.147 6.604-14.75 14.75-14.75z"/><path fill="#EA4335" d="M45.59 14.75c0 8.146-6.603 14.75-14.75 14.75H29.5V1.34C29.5.6 30.1 0 30.84 0c8.147 0 14.75 6.604 14.75 14.75z"/><path fill="#4285F4" d="M44.25 45.59c-8.146 0-14.75-6.603-14.75-14.75V29.5h28.16c.74 0 1.34.6 1.34 1.34 0 8.147-6.604 14.75-14.75 14.75z"/><path fill="#34A853" d="M13.41 44.25c0-8.146 6.603-14.75 14.75-14.75h1.34v28.16c0 .74-.6 1.34-1.34 1.34-8.147 0-14.75-6.604-14.75-14.75z"/></g>'],
+        'other'        => ['label' => 'Enlace',        'color' => '#6c757d', 'svg_paths' => '<path d="M4.715 6.542 3.343 7.914a3 3 0 1 0 4.243 4.243l1.828-1.829A3 3 0 0 0 8.586 5.5L8 6.086a1 1 0 0 0-.154.199 2 2 0 0 1 .861 3.337L6.88 11.45a2 2 0 1 1-2.83-2.83l.793-.792a4 4 0 0 1-.128-1.287z"/><path d="M6.586 4.672A3 3 0 0 0 7.414 9.5l.775-.776a2 2 0 0 1-.896-3.346L9.12 3.55a2 2 0 1 1 2.83 2.83l-.793.792c.112.42.155.855.128 1.287l1.372-1.372a3 3 0 1 0-4.243-4.243z"/>'],
+    ];
+
+    public function __construct() {
+        $this->db = getDB();
+    }
+
+    /**
+     * Obtener todos los links de una ruta
+     */
+    public function getByRouteId(int $route_id): array {
+        try {
+            $stmt = $this->db->prepare(
+                'SELECT * FROM route_links WHERE route_id = ? ORDER BY sort_order ASC, id ASC'
+            );
+            $stmt->execute([$route_id]);
+            return $stmt->fetchAll();
+        } catch (PDOException $e) {
+            error_log('Error al obtener links de la ruta: ' . $e->getMessage());
+            return [];
+        }
+    }
+
+    /**
+     * Reemplaza todos los links de una ruta (delete + insert)
+     *
+     * @param int   $route_id
+     * @param array $links  Array de ['link_type'=>..., 'url'=>..., 'label'=>..., 'sort_order'=>...]
+     */
+    public function replaceForRoute(int $route_id, array $links): bool {
+        try {
+            $this->db->beginTransaction();
+
+            $this->db->prepare('DELETE FROM route_links WHERE route_id = ?')->execute([$route_id]);
+
+            if (!empty($links)) {
+                $stmt = $this->db->prepare(
+                    'INSERT INTO route_links (route_id, link_type, url, label, sort_order)
+                     VALUES (?, ?, ?, ?, ?)'
+                );
+                foreach ($links as $i => $link) {
+                    $type = $link['link_type'] ?? 'other';
+                    if (!array_key_exists($type, self::TYPES)) {
+                        $type = 'other';
+                    }
+                    $url = trim($link['url'] ?? '');
+                    if ($url === '') continue;
+
+                    $stmt->execute([
+                        $route_id,
+                        $type,
+                        $url,
+                        trim($link['label'] ?? '') ?: null,
+                        (int) ($link['sort_order'] ?? $i),
+                    ]);
+                }
+            }
+
+            $this->db->commit();
+            return true;
+        } catch (PDOException $e) {
+            $this->db->rollBack();
+            error_log('Error al guardar links de la ruta: ' . $e->getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Convierte los links de BD en array JSON-friendly para el frontend
+     */
+    public static function toApiArray(array $dbRows): array {
+        return array_map(function ($row) {
+            $meta = self::TYPES[$row['link_type']] ?? self::TYPES['other'];
+            return [
+                'type'      => $row['link_type'],
+                'url'       => $row['url'],
+                'label'     => $row['label'] ?: $meta['label'],
+                'color'     => $meta['color'],
+                'svg_paths' => $meta['svg_paths'],
+            ];
+        }, $dbRows);
+    }
+
+    /**
+     * Genera el SVG inline para un tipo de link
+     */
+    public static function getSvg(string $type, int $size = 16): string {
+        $meta = self::TYPES[$type] ?? self::TYPES['other'];
+        return sprintf(
+            '<svg xmlns="http://www.w3.org/2000/svg" width="%d" height="%d" fill="%s" viewBox="0 0 16 16">%s</svg>',
+            $size, $size, htmlspecialchars($meta['color']), $meta['svg_paths']
+        );
+    }
+
+    /**
+     * Devuelve los tipos disponibles (para formularios)
+     */
+    public static function getTypes(): array {
+        return self::TYPES;
+    }
+}

--- a/trip.php
+++ b/trip.php
@@ -7,7 +7,9 @@ require_once __DIR__ . '/src/models/Route.php';
 require_once __DIR__ . '/src/models/Point.php';
 require_once __DIR__ . '/src/models/TripTag.php';
 require_once __DIR__ . '/src/models/PoiLink.php';
+require_once __DIR__ . '/src/models/RouteLink.php';
 require_once __DIR__ . '/src/helpers/FileHelper.php';
+require_once __DIR__ . '/src/helpers/DateTimeHelper.php';
 require_once __DIR__ . '/src/models/Settings.php';
 
 // Check feature flag
@@ -31,6 +33,7 @@ $routeModel   = new Route();
 $pointModel   = new Point();
 $tripTagModel = new TripTag();
 $poiLinkModel = new PoiLink();
+$routeLinkModel = new RouteLink();
 
 $trip = $tripModel->getById($tripId);
 
@@ -44,29 +47,40 @@ $routes = $routeModel->getByTripId($tripId);
 $tags = $tripTagModel->getByTripId($tripId);
 $points = $pointModel->getAll($tripId);
 
-// Sort points by visit_date (oldest to newest)
-usort($points, function($a, $b) {
-    $dateA = strtotime($a['visit_date'] ?? '1970-01-01 00:00:00');
-    $dateB = strtotime($b['visit_date'] ?? '1970-01-01 00:00:00');
-    return $dateA - $dateB;
-});
-
-// Calcular estadísticas
+// Calcular estadísticas y procesar rutas
 $totalDistance = 0;
 $processedRoutes = [];
+$timelineItems = [];
+
 foreach ($routes as $route) {
     $dist = (int) ($route['distance_meters'] ?? 0);
     $totalDistance += $dist;
     
-    $processedRoutes[] = [
+    $routeLinks = RouteLink::toApiArray($routeLinkModel->getByRouteId((int) $route['id']));
+    
+    $processedRoute = [
         'id' => (int) $route['id'],
         'transport_type' => $route['transport_type'],
         'color' => $route['color'],
-        'geojson' => json_decode($route['geojson_data'], true)
+        'geojson' => json_decode($route['geojson_data'], true),
+        'name' => $route['name'] ?? null,
+        'description' => $route['description'] ?? null,
+        'start_datetime' => $route['start_datetime'] ?? null,
+        'end_datetime' => $route['end_datetime'] ?? null,
+        'links' => $routeLinks,
+    ];
+    $processedRoutes[] = $processedRoute;
+    
+    // Agregar a timeline (todas las rutas, sin filtrar)
+    $timelineItems[] = [
+        'type' => 'route',
+        'item' => $processedRoute,
+        'sort_date' => !empty($route['start_datetime']) ? strtotime($route['start_datetime']) : PHP_INT_MAX,
+        'has_date' => !empty($route['start_datetime']),
     ];
 }
 
-// Procesar puntos para JS y visualización
+// Procesar puntos para JS y timeline
 $processedPoints = [];
 foreach ($points as $point) {
     $thumbnail_url = null;
@@ -77,7 +91,7 @@ foreach ($points as $point) {
     
     $links = PoiLink::toApiArray($poiLinkModel->getByPoiId((int) $point['id']));
 
-    $processedPoints[] = [
+    $processedPoint = [
         'id' => (int) $point['id'],
         'title' => $point['title'],
         'description' => $point['description'],
@@ -89,7 +103,26 @@ foreach ($points as $point) {
         'visit_date' => $point['visit_date'],
         'links' => $links,
     ];
+    $processedPoints[] = $processedPoint;
+    
+    // Agregar a timeline
+    $timelineItems[] = [
+        'type' => 'point',
+        'item' => $processedPoint,
+        'sort_date' => strtotime($point['visit_date'] ?? '1970-01-01 00:00:00'),
+        'has_date' => !empty($point['visit_date']),
+    ];
 }
+
+// Ordenar timeline: primero los que tienen fecha (por fecha), luego los que no tienen fecha
+usort($timelineItems, function($a, $b) {
+    // Si ambos tienen fecha o ambos no tienen, ordenar por fecha
+    if ($a['has_date'] === $b['has_date']) {
+        return $a['sort_date'] - $b['sort_date'];
+    }
+    // Los que tienen fecha van primero
+    return $a['has_date'] ? -1 : 1;
+});
 
 $tripDataForJS = [
     'id' => (int) $trip['id'],
@@ -206,35 +239,74 @@ $statsIcons = [
                 </div>
                 <?php endif; ?>
 
-                <?php if (!empty($processedPoints)): ?>
+                <?php if (!empty($timelineItems)): ?>
                 <div class="trip-timeline">
-                    <p class="timeline-heading"><?= __('map.points') ?></p>
                     <div class="timeline-points">
-                        <?php foreach ($processedPoints as $point): ?>
-                        <div class="timeline-point" data-id="<?= $point['id'] ?>" data-lat="<?= $point['latitude'] ?>" data-lng="<?= $point['longitude'] ?>">
-                            <div class="point-marker"></div>
-                            <div class="point-content">
-                                <div class="point-header">
-                                    <h3 class="point-title"><?= htmlspecialchars($point['title']) ?></h3>
-                                    <?php if ($point['visit_date']): ?>
-                                        <span class="point-date"><?= date('d M Y', strtotime($point['visit_date'])) ?></span>
-                                    <?php endif; ?>
+                        <?php foreach ($timelineItems as $timelineItem): ?>
+                            <?php if ($timelineItem['type'] === 'route'): ?>
+                                <?php $route = $timelineItem['item']; ?>
+                                <div class="timeline-point timeline-route" data-route-id="<?= $route['id'] ?>">
+                                    <div class="point-marker" style="background-color: <?= htmlspecialchars($route['color']) ?>;">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2">
+                                            <path d="M22 12h-4l-3 9L9 3l-3 9H2"/>
+                                        </svg>
+                                    </div>
+                                    <div class="point-content">
+                                        <div class="point-header">
+                                            <?php if (!empty($route['name'])): ?>
+                                                <h3 class="point-title"><?= htmlspecialchars($route['name']) ?></h3>
+                                            <?php else: ?>
+                                                <h3 class="point-title text-muted"><?= __('map.route') ?> #<?= $route['id'] ?></h3>
+                                            <?php endif; ?>
+                                            <?php if (!empty($route['start_datetime'])): ?>
+                                                <span class="point-date"><?= formatRouteDatetime($route['start_datetime'], $route['end_datetime'] ?? null) ?></span>
+                                            <?php endif; ?>
+                                        </div>
+                                        <?php if (!empty($route['description'])): ?>
+                                        <div class="route-description"><?= nl2br(htmlspecialchars($route['description'])) ?></div>
+                                        <?php endif; ?>
+                                        <?php if (!empty($route['links'])): ?>
+                                        <div class="point-links">
+                                            <?php foreach ($route['links'] as $link): ?>
+                                            <a href="<?= htmlspecialchars($link['url']) ?>"
+                                               target="_blank"
+                                               rel="noopener noreferrer"
+                                               class="point-link-btn"
+                                               title="<?= htmlspecialchars($link['label']) ?>">
+                                                <?= RouteLink::getSvg($link['type'], 14) ?>
+                                            </a>
+                                            <?php endforeach; ?>
+                                        </div>
+                                        <?php endif; ?>
+                                    </div>
                                 </div>
-                                <?php if (!empty($point['links'])): ?>
-                                <div class="point-links">
-                                    <?php foreach ($point['links'] as $link): ?>
-                                    <a href="<?= htmlspecialchars($link['url']) ?>"
-                                       target="_blank"
-                                       rel="noopener noreferrer"
-                                       class="point-link-btn"
-                                       title="<?= htmlspecialchars($link['label']) ?>">
-                                        <?= PoiLink::getSvg($link['type'], 14) ?>
-                                    </a>
-                                    <?php endforeach; ?>
+                            <?php else: ?>
+                                <?php $point = $timelineItem['item']; ?>
+                                <div class="timeline-point" data-id="<?= $point['id'] ?>" data-lat="<?= $point['latitude'] ?>" data-lng="<?= $point['longitude'] ?>">
+                                    <div class="point-marker"></div>
+                                    <div class="point-content">
+                                        <div class="point-header">
+                                            <h3 class="point-title"><?= htmlspecialchars($point['title']) ?></h3>
+                                            <?php if ($point['visit_date']): ?>
+                                                <span class="point-date"><?= date('d M Y', strtotime($point['visit_date'])) ?></span>
+                                            <?php endif; ?>
+                                        </div>
+                                        <?php if (!empty($point['links'])): ?>
+                                        <div class="point-links">
+                                            <?php foreach ($point['links'] as $link): ?>
+                                            <a href="<?= htmlspecialchars($link['url']) ?>"
+                                               target="_blank"
+                                               rel="noopener noreferrer"
+                                               class="point-link-btn"
+                                               title="<?= htmlspecialchars($link['label']) ?>">
+                                                <?= PoiLink::getSvg($link['type'], 14) ?>
+                                            </a>
+                                            <?php endforeach; ?>
+                                        </div>
+                                        <?php endif; ?>
+                                    </div>
                                 </div>
-                                <?php endif; ?>
-                            </div>
-                        </div>
+                            <?php endif; ?>
                         <?php endforeach; ?>
                     </div>
                 </div>
@@ -253,7 +325,12 @@ $statsIcons = [
             <div class="trip-media">
                 <?php 
                 $pointsWithImages = array_filter($processedPoints, function($p) { return !empty($p['image_url']); });
-                // Sort by visit_date (newest first on left, oldest last on right)
+                // Sort by visit_date (oldest first on left, newest last on right)
+                usort($pointsWithImages, function($a, $b) {
+                    $dateA = strtotime($a['visit_date'] ?? '1970-01-01 00:00:00');
+                    $dateB = strtotime($b['visit_date'] ?? '1970-01-01 00:00:00');
+                    return $dateA - $dateB;
+                });
 
                 if (!empty($pointsWithImages)): 
                 ?>


### PR DESCRIPTION
feat(routes): agregar metadata, links externos y fecha/hora a rutas

Extiende la funcionalidad de rutas/trayectos para que tengan la misma
riqueza de datos que los puntos de interés (POIs), incluyendo nombre,
descripción, fecha/hora de inicio y fin, e imagen.

### Nuevas funcionalidades

- **Campos de metadata para rutas**: nombre, descripción e imagen
- **Fecha y hora de trayecto**: campos start_datetime y end_datetime
- **Links externos tipificados**: 12 tipos de links (Website, Google Maps,
  Instagram, Facebook, Twitter/X, TripAdvisor, Booking, Airbnb, YouTube,
  Wikipedia, Google Photos, Enlace genérico)
- **Timeline unificado**: rutas y puntos se muestran intercalados en la
  página del viaje, ordenados por fecha
- **Click en ruta del timeline**: enfoca el mapa en la ruta seleccionada
- **Popups mejorados**: el mapa público muestra nombre, fecha y links
  de las rutas

### Cambios en archivos

**Base de datos:**
- `install/migrations/017_route_metadata.php`: agrega campos name,
  description, image_path a tabla routes
- `install/migrations/018_route_links_table.php`: crea tabla route_links
- `install/migrations/019_route_datetime.php`: agrega campos
  start_datetime y end_datetime a tabla routes

**Modelos:**
- `src/models/Route.php`: actualiza métodos create() y update() para
  incluir nuevos campos
- `src/models/RouteLink.php`: nuevo modelo (paralelo a PoiLink) con
  métodos getByRouteId(), replaceForRoute(), toApiArray(), getSvg(),
  getTypes()

**API:**
- `api/get_all_data.php`: incluye todos los nuevos campos de ruta y
  links en el response JSON

**Frontend - Editor de rutas:**
- `admin/trip_edit_map.php`: pasa/guarda campos y links, expone
  routeLinkTypes al JavaScript
- `assets/js/trip_map.js`: modal de edición con campos de fecha,
  nombre, descripción y gestión dinámica de links

**Frontend - Página del viaje:**
- `trip.php`: timeline unificado de rutas y puntos ordenados por fecha,
  con iconos diferenciados para cada tipo
- `assets/js/trip_single.js`: click en rutas enfoca el mapa usando
  fitBounds
- `assets/css/trip.css`: estilos para rutas en timeline unificado

**Frontend - Mapa público:**
- `assets/js/public_map.js`: popups con nombre, fecha y links de rutas
- `assets/js/public_map_leaflet.js`: popups con nombre, fecha y links
  de rutas

**Traducciones:**
- `lang/es.json` y `lang/en.json`: keys para todos los textos nuevos

### Cambios de breaking

Ninguno. Los cambios son completamente retrocompatibles. Las rutas
existentes funcionan sin cambios; los nuevos campos son opcionales.

---

Desarrollado con asistencia de IA (modelo opencode/big-pickle).