### PR TITLE
Restricción de acceso al sitio público

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [1.0.240.1] – 2026-04-16
+- Control de acceso mejorado: protección de contraseña en index.php y trip.php
+- Admin logueado obtiene acceso directo sin ingresar contraseña
+- Nueva función `check_public_access()` en `includes/public_access.php` para verificación unificada de acceso
+- Función `is_trip_accessible()` para validar acceso a viajes específicos
+- Función `show_public_login_page()` para mostrar página de login con estética consistente
+- Interfaz de contraseña mejorada: mismo container/card/logo y fondo que login.php
+- trip.php ahora protegido: no se puede bypassear conociendo el ID si la contraseña es requerida
+- APIs actualizadas: `get_all_data.php` y `get_trip.php` ahora validan acceso con `check_public_access()`
+- Estilos CSS actualizados: form-label, form-group, alert para formularios de login público
+- Fondo de página de login unificado con gradientes oscuros (consistente con admin login)
+- Fix: Admin con sesión activa ahora obtiene acceso directo a las APIs públicas
+
 ## [1.0.240] – 2026-04-16
 - Nuevo sistema de restricción de acceso al sitio público con contraseñas compartidas
 - Modelo `PasswordShare` para gestión de enlaces compartidos con expiración y activación

--- a/api/get_all_data.php
+++ b/api/get_all_data.php
@@ -9,6 +9,7 @@ header('Content-Type: application/json; charset=utf-8');
 
 require_once __DIR__ . '/../config/db.php';
 require_once __DIR__ . '/../config/config.php';
+require_once __DIR__ . '/../includes/public_access.php';
 require_once __DIR__ . '/../src/models/Trip.php';
 require_once __DIR__ . '/../src/models/Route.php';
 require_once __DIR__ . '/../src/models/Point.php';
@@ -19,19 +20,16 @@ require_once __DIR__ . '/../src/models/PasswordShare.php';
 require_once __DIR__ . '/../src/helpers/FileHelper.php';
 
 try {
-    $settingsModel = new Settings(getDB());
-    $requiresPass = $settingsModel->get('requires_pass', false);
+    // Verificar acceso al sitio público (admin logueado o contraseña válida)
+    $accessInfo = check_public_access();
     
-    $allowedTrips = '*'; // por defecto todos
-    if ($requiresPass) {
-        session_start();
-        if (!isset($_SESSION['public_password_trips'])) {
-            http_response_code(403);
-            echo json_encode(['success' => false, 'error' => 'Access denied']);
-            exit;
-        }
-        $allowedTrips = $_SESSION['public_password_trips'];
+    if (!$accessInfo['access']) {
+        http_response_code(403);
+        echo json_encode(['success' => false, 'error' => 'Access denied']);
+        exit;
     }
+    
+    $allowedTrips = $accessInfo['trips'];
     
     $tripModel      = new Trip();
     $routeModel     = new Route();

--- a/api/get_trip.php
+++ b/api/get_trip.php
@@ -9,6 +9,7 @@ header('Content-Type: application/json; charset=utf-8');
 
 require_once __DIR__ . '/../config/db.php';
 require_once __DIR__ . '/../config/config.php';
+require_once __DIR__ . '/../includes/public_access.php';
 require_once __DIR__ . '/../src/models/Trip.php';
 require_once __DIR__ . '/../src/models/Route.php';
 require_once __DIR__ . '/../src/models/Point.php';
@@ -21,6 +22,13 @@ try {
     }
 
     $tripId = (int)$_GET['id'];
+    
+    // Verificar acceso al sitio público
+    $accessInfo = check_public_access();
+    if (!$accessInfo['access'] || !is_trip_accessible($tripId, $accessInfo)) {
+        http_response_code(403);
+        throw new Exception('Acceso denegado');
+    }
     
     $tripModel = new Trip();
     $routeModel = new Route();

--- a/assets/css/public_map.css
+++ b/assets/css/public_map.css
@@ -1930,3 +1930,35 @@ body {
 .login-footer a:hover {
     color: #475569;
 }
+
+/* ========== Form Styles for Login ========== */
+.form-label {
+    display: block;
+    margin-bottom: 0.5rem;
+    font-weight: 500;
+    font-size: 0.875rem;
+    color: #1e293b;
+}
+
+.form-group {
+    margin-bottom: 1rem;
+}
+
+.mb-3 {
+    margin-bottom: 1rem;
+}
+
+/* ========== Alert Styles ========== */
+.alert {
+    padding: 0.75rem 1rem;
+    margin-bottom: 1rem;
+    border: 1px solid transparent;
+    border-radius: 0.375rem;
+    font-size: 0.875rem;
+}
+
+.alert-danger {
+    color: #b91c1c;
+    background-color: #fee2e2;
+    border-color: #fecaca;
+}

--- a/includes/public_access.php
+++ b/includes/public_access.php
@@ -1,0 +1,218 @@
+<?php
+/**
+ * Public Access Control Helper
+ * 
+ * Gestiona el control de acceso al sitio público con contraseñas compartidas
+ * Permite acceso directo si el usuario admin está logueado
+ */
+
+require_once __DIR__ . '/../config/config.php';
+require_once __DIR__ . '/../config/db.php';
+require_once __DIR__ . '/auth.php';
+require_once __DIR__ . '/../src/models/PasswordShare.php';
+require_once __DIR__ . '/../src/models/Settings.php';
+
+/**
+ * Verifica si el usuario tiene acceso al sitio público
+ * Si es admin logueado, permite acceso directo
+ * Si el sitio requiere contraseña, verifica sesión de acceso público
+ * 
+ * @return array|null Array con 'access' => bool, 'trips' => string (viajes permitidos o '*')
+ */
+function check_public_access() {
+    // Si el usuario es admin logueado, permitir acceso directo
+    if (is_logged_in()) {
+        return [
+            'access' => true,
+            'trips' => '*', // Admin ve todos los viajes
+            'is_admin' => true
+        ];
+    }
+
+    // Iniciar sesión si no está iniciada
+    if (session_status() === PHP_SESSION_NONE) {
+        session_start();
+    }
+
+    // Obtener configuración
+    $settingsModel = new Settings(getDB());
+    $requiresPass = $settingsModel->get('requires_pass', false);
+
+    // Si no requiere contraseña, permitir acceso
+    if (!$requiresPass) {
+        return [
+            'access' => true,
+            'trips' => '*',
+            'is_admin' => false
+        ];
+    }
+
+    // Verificar contraseña en sesión
+    $allowedTrips = '*';
+    $hasValidPassword = false;
+
+    if (isset($_POST['password'])) {
+        // Intentar validar contraseña ingresada
+        $passwordShareModel = new PasswordShare(getDB());
+        $validationResult = $passwordShareModel->validatePassword($_POST['password']);
+        
+        if ($validationResult !== false) {
+            $_SESSION['public_password_id'] = $validationResult['id'];
+            $_SESSION['public_password_trips'] = $validationResult['trips'];
+            $hasValidPassword = true;
+            $allowedTrips = $validationResult['trips'];
+        } else {
+            return [
+                'access' => false,
+                'trips' => null,
+                'is_admin' => false,
+                'error' => __('public.requires_pass_invalid') ?? 'Contraseña inválida'
+            ];
+        }
+    } elseif (isset($_SESSION['public_password_id'])) {
+        // Revalidar contraseña en sesión
+        $passwordShareModel = new PasswordShare(getDB());
+        $allowedTrips = $passwordShareModel->validatePasswordById($_SESSION['public_password_id']);
+        
+        if ($allowedTrips !== false) {
+            $hasValidPassword = true;
+            $_SESSION['public_password_trips'] = $allowedTrips;
+        } else {
+            // Contraseña expirada o desactivada
+            unset($_SESSION['public_password_id']);
+            unset($_SESSION['public_password_trips']);
+            return [
+                'access' => false,
+                'trips' => null,
+                'is_admin' => false,
+                'error' => __('public.requires_pass_expired') ?? 'La contraseña ha expirado'
+            ];
+        }
+    } elseif (isset($_SESSION['public_password_trips'])) {
+        // Fallback para sesiones antiguas: invalidar
+        unset($_SESSION['public_password_trips']);
+    }
+
+    if ($hasValidPassword) {
+        return [
+            'access' => true,
+            'trips' => $allowedTrips,
+            'is_admin' => false
+        ];
+    }
+
+    // No tiene acceso válido
+    return [
+        'access' => false,
+        'trips' => null,
+        'is_admin' => false,
+        'error' => null
+    ];
+}
+
+/**
+ * Verifica si un viaje específico es accesible
+ * 
+ * @param int $tripId ID del viaje a verificar
+ * @param array $accessInfo Array retornado por check_public_access()
+ * @return bool True si el viaje es accesible
+ */
+function is_trip_accessible($tripId, $accessInfo) {
+    if (!$accessInfo['access']) {
+        return false;
+    }
+
+    if ($accessInfo['trips'] === '*') {
+        return true; // Acceso a todos los viajes
+    }
+
+    // Verificar si el viaje está en la lista de permitidos
+    $allowedTrips = explode(',', $accessInfo['trips']);
+    return in_array((string)$tripId, array_map('trim', $allowedTrips));
+}
+
+/**
+ * Muestra la página de login para acceder al sitio público
+ * 
+ * @param string $siteTitle Título del sitio
+ * @param string $version Versión de la app
+ * @param string|null $passwordError Mensaje de error si la contraseña fue inválida
+ */
+function show_public_login_page($siteTitle, $version, $passwordError = null) {
+    $siteFavicon = SITE_FAVICON ?? '';
+    ?>
+    <!DOCTYPE html>
+    <html lang="<?= current_lang() ?>">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title><?= htmlspecialchars($siteTitle) ?> - <?= __('public.requires_pass_title') ?? 'Acceso Requerido' ?></title>
+        <link rel="stylesheet" href="<?= ASSETS_URL ?>/css/public_map.css?v=<?php echo $version; ?>">
+        <?php if (!empty($siteFavicon)): ?>
+        <link rel="icon" type="image/x-icon" href="<?= htmlspecialchars($siteFavicon) ?>">
+        <?php endif; ?>
+        <style>
+            .login-page {
+                background: var(--primary-dark-slate, #1e293b);
+                background-image: 
+                    radial-gradient(circle at 25% 25%, rgba(51, 65, 85, 0.6) 0%, transparent 50%),
+                    radial-gradient(circle at 75% 75%, rgba(51, 65, 85, 0.4) 0%, transparent 50%);
+            }
+            :root {
+                --primary-dark-slate: #1e293b;
+                --hover-dark-slate: #334155;
+            }
+        </style>
+    </head>
+    <body class="login-page">
+        <div class="login-container">
+            <div class="login-card">
+                <div class="login-header">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" class="bi bi-map" viewBox="0 0 16 16" style="width: 48px; height: 48px; color: #1e293b; margin: 0 auto 10px; display: block;">
+                        <path fill-rule="evenodd" d="M15.817.113A.5.5 0 0 1 16 .5v14a.5.5 0 0 1-.402.49l-5 1a.5.5 0 0 1-.196 0L5.5 15.01l-4.902.98A.5.5 0 0 1 0 15.5v-14a.5.5 0 0 1 .402-.49l5-1a.5.5 0 0 1 .196 0L10.5.99l4.902-.98a.5.5 0 0 1 .415.103M10 1.91l-4-.8v12.98l4 .8zm1 12.98 4-.8V1.11l-4 .8zm-6-.8V1.11l-4 .8v12.98z"/>
+                    </svg>
+                    <h1 class="login-title">TravelMap</h1>
+                    <!-- <h1 class="login-title"><?= htmlspecialchars($siteTitle) ?></h1> -->
+                    <p class="login-subtitle"><?= __('public.requires_pass_description') ?? 'Ingrese la contraseña para acceder al mapa de viajes' ?></p>
+                </div>
+                
+                <form method="post" class="login-form">
+                    <div class="form-group mb-3">
+                        <label for="password" class="form-label"><?= __('public.password') ?? 'Contraseña' ?></label>
+                        <input type="password" 
+                               class="form-control" 
+                               id="password" 
+                               name="password" 
+                               required 
+                               autofocus
+                               placeholder="<?= __('public.enter_password') ?? 'Ingrese la contraseña' ?>">
+                    </div>
+                    
+                    <?php if (!empty($passwordError)): ?>
+                        <div class="alert alert-danger mb-3">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="margin-right: 8px; display: inline-block; vertical-align: middle;">
+                                <circle cx="12" cy="12" r="10"></circle>
+                                <line x1="12" y1="8" x2="12" y2="12"></line>
+                                <line x1="12" y1="16" x2="12.01" y2="16"></line>
+                            </svg>
+                            <span><?= htmlspecialchars($passwordError) ?></span>
+                        </div>
+                    <?php endif; ?>
+                    
+                    <button type="submit" class="btn btn-primary" style="width: 100%; padding: 12px; font-size: 16px; font-weight: 600;">
+                        <?= __('public.access_map') ?? 'Acceder al Mapa' ?>
+                    </button>
+                </form>
+                
+                <div class="login-footer">
+                    <a href="<?= BASE_URL ?>/admin/" class="text-muted"><?= __('app.admin_panel') ?? 'Panel de Administración' ?></a>
+                </div>
+            </div>
+        </div>
+
+        <!-- Bootstrap JS Bundle - Local -->
+        <script src="<?= ASSETS_URL ?>/vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
+    </body>
+    </html>
+    <?php
+}

--- a/index.php
+++ b/index.php
@@ -2,113 +2,29 @@
 // Cargar configuración para las constantes
 require_once __DIR__ . '/config/config.php';
 require_once __DIR__ . '/version.php';
+require_once __DIR__ . '/includes/public_access.php';
 
 // Load settings to get map renderer preference
 require_once __DIR__ . '/config/db.php';
 require_once __DIR__ . '/src/models/Settings.php';
-require_once __DIR__ . '/src/models/PasswordShare.php';
 
 $settingsModel = new Settings(getDB());
 $mapRenderer = $settingsModel->get('map_renderer', 'maplibre');
 $showFooterNote = $settingsModel->get('show_footer_note', true);
 $footerNoteText = $settingsModel->get('footer_note_text', '');
-$requiresPass = $settingsModel->get('requires_pass', false);
 
-// Verificar acceso con contraseña si es requerido
-$hasValidPassword = false;
-$allowedTrips = '*'; // por defecto todos
+// Verificar acceso al sitio público (con contraseña si es requerido)
+$accessInfo = check_public_access();
+$allowedTrips = $accessInfo['trips'];
 
-if ($requiresPass) {
-    session_start();
-    $passwordShareModel = new PasswordShare(getDB());
-    
-    if (isset($_POST['password'])) {
-        // Intentar validar contraseña
-        $validationResult = $passwordShareModel->validatePassword($_POST['password']);
-        if ($validationResult !== false) {
-            $_SESSION['public_password_id'] = $validationResult['id'];
-            $_SESSION['public_password_trips'] = $validationResult['trips'];
-            $hasValidPassword = true;
-            $allowedTrips = $validationResult['trips'];
-        } else {
-            $passwordError = __('public.requires_pass_invalid') ?? 'Invalid password';
-        }
-    } elseif (isset($_SESSION['public_password_id'])) {
-        // Revalidar la contraseña por ID en cada carga de página
-        $allowedTrips = $passwordShareModel->validatePasswordById($_SESSION['public_password_id']);
-        if ($allowedTrips !== false) {
-            $hasValidPassword = true;
-            // Actualizar los trips en la sesión por si cambiaron
-            $_SESSION['public_password_trips'] = $allowedTrips;
-        } else {
-            // Contraseña ya no es válida, limpiar sesión
-            unset($_SESSION['public_password_id']);
-            unset($_SESSION['public_password_trips']);
-        }
-    } elseif (isset($_SESSION['public_password_trips'])) {
-        // Fallback para sesiones antiguas: invalidar para forzar re-login
-        unset($_SESSION['public_password_trips']);
-    }
-    
-    if (!$hasValidPassword) {
-        // Mostrar página de login
-        ?>
-        <!DOCTYPE html>
-        <html lang="<?= current_lang() ?>">
-        <head>
-            <meta charset="UTF-8">
-            <meta name="viewport" content="width=device-width, initial-scale=1.0">
-            <title><?= htmlspecialchars(SITE_TITLE) ?> - <?= __('public.requires_pass_title') ?? 'Requires Password' ?></title>
-            <link rel="stylesheet" href="<?= ASSETS_URL ?>/css/public_map.css?v=<?php echo $version; ?>">
-            <link rel="icon" type="image/x-icon" href="<?= htmlspecialchars(SITE_FAVICON) ?>">
-        </head>
-        <body class="login-page">
-            <div class="login-container">
-                <div class="login-card">
-                    <div class="login-header">
-                        <h1 class="login-title"><?= __('public.requires_pass_title') ?? 'Requires Password' ?></h1>
-                        <p class="login-subtitle"><?= __('public.requires_pass_description') ?? 'Enter the password to access the travel map' ?></p>
-                    </div>
-                    
-                    <form method="post" class="login-form">
-                        <div class="form-group">
-                            <label for="password" class="form-label"><?= __('public.password') ?? 'Password' ?></label>
-                            <input type="password" 
-                                   class="form-control" 
-                                   id="password" 
-                                   name="password" 
-                                   required 
-                                   autofocus
-                                   placeholder="<?= __('public.enter_password') ?? 'Enter password' ?>">
-                        </div>
-                        
-                        <?php if (isset($passwordError)): ?>
-                            <div class="alert alert-danger">
-                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                    <circle cx="12" cy="12" r="10"></circle>
-                                    <line x1="12" y1="8" x2="12" y2="12"></line>
-                                    <line x1="12" y1="16" x2="12.01" y2="16"></line>
-                                </svg>
-                                <span><?= htmlspecialchars($passwordError) ?></span>
-                            </div>
-                        <?php endif; ?>
-                        
-                        <button type="submit" class="btn btn-primary btn-block">
-                            <?= __('public.access_map') ?? 'Access Map' ?>
-                        </button>
-                    </form>
-                    
-                    <div class="login-footer">
-                        <a href="admin/" class="text-muted"><?= __('app.admin_panel') ?? 'Admin Panel' ?></a>
-                    </div>
-                </div>
-            </div>
-        </body>
-        </html>
-        <?php
-        exit;
-    }
-} else {
+if (!$accessInfo['access']) {
+    // Mostrar página de login
+    show_public_login_page(SITE_TITLE, $version, $accessInfo['error'] ?? null);
+    exit;
+}
+
+// Admin o acceso con contraseña válido - continuar cargando el sitio
+if (session_status() === PHP_SESSION_NONE) {
     session_start();
 }
 ?>

--- a/trip.php
+++ b/trip.php
@@ -2,6 +2,7 @@
 require_once __DIR__ . '/config/config.php';
 require_once __DIR__ . '/version.php';
 require_once __DIR__ . '/config/db.php';
+require_once __DIR__ . '/includes/public_access.php';
 require_once __DIR__ . '/src/models/Trip.php';
 require_once __DIR__ . '/src/models/Route.php';
 require_once __DIR__ . '/src/models/Point.php';
@@ -11,6 +12,30 @@ require_once __DIR__ . '/src/helpers/FileHelper.php';
 require_once __DIR__ . '/src/helpers/DateTimeHelper.php';
 require_once __DIR__ . '/src/models/Settings.php';
 
+// Verificar acceso al sitio público (con contraseña si es requerido)
+$accessInfo = check_public_access();
+
+// Validar ID del viaje
+if (!isset($_GET['id']) || !is_numeric($_GET['id'])) {
+    header("HTTP/1.0 404 Not Found");
+    die("Trip ID missing or invalid");
+}
+
+$tripId = (int)$_GET['id'];
+
+// Verificar que el viaje sea accesible para este usuario
+if (!is_trip_accessible($tripId, $accessInfo)) {
+    // Si no tiene acceso, mostrar página de login
+    if (!$accessInfo['access']) {
+        show_public_login_page(SITE_TITLE, $version, $accessInfo['error'] ?? null);
+    } else {
+        // Tiene acceso al sitio pero no a este viaje específico
+        header("HTTP/1.0 403 Forbidden");
+        die("You do not have access to this trip");
+    }
+    exit;
+}
+
 // Check feature flag
 $_settingsModel = new Settings(getDB());
 if (!$_settingsModel->get('trip_page_enabled', true)) {
@@ -18,13 +43,11 @@ if (!$_settingsModel->get('trip_page_enabled', true)) {
     die("Page not found");
 }
 
-// Validar ID
-if (!isset($_GET['id']) || !is_numeric($_GET['id'])) {
-    header("HTTP/1.0 404 Not Found");
-    die("Trip ID missing or invalid");
+// Iniciar sesión si no está iniciada
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
 }
 
-$tripId = (int)$_GET['id'];
 $db = getDB();
 
 $tripModel    = new Trip();


### PR DESCRIPTION
Restricción de acceso al sitio público
Relacionado con #50 

Me parece que este PR es medio heavy, tal vez requiera un poco de revisión de los Gurús de este proyecto. Como siempre _"en mi máquina funciona"_. 

### Funcionamiento:
Sin restricción: El sitio funciona normalmente
Con restricción activada: Muestra página de login simplificada
Contraseña válida: Acceso a viajes específicos o todos (*)
Contraseña expirada/inactiva: Acceso denegado
Gestión: Admin puede crear, desactivar contraseñas desde usuarios

### Base de Datos:
Nueva tabla password_shares con campos: `id` ,`password`, `trips`, `description`, `created_at`, `expires_at`, `active` 
Migración 022_password_shares.php creada

### Configuración:
Nuevo setting requires_pass (boolean) en admin/settings.php#site
Checkbox agregado justo antes de "Mostrar nota del pie de página"

### Lógica de Acceso:
Página de login simplificada cuando requires_pass = true
Validación de contraseña con expiración y estado activo
Filtrado de viajes en api/get_all_data.php según contraseña

### Interfaz de Administración:
Nueva sección "Compartir con Contraseña" en admin/users.php
Tabla de contraseñas activas con botón de desactivar
Formulario admin/share_form.php para crear contraseñas

### Características del Formulario:
Contraseña pre-generada de 10 caracteres (letras/números)
Descripción para comentarios o para indicar con quién se comparte la contraseña (familia, amigos fútbol, etc)
Opciones de validez: 1 Semana, 1 Mes, 1 Año, Para Siempre
Selector de viajes idéntico al público (Todos, Ninguno, Todos + Futuros)
"Todos + Futuros" guarda '*' para incluir viajes futuros